### PR TITLE
Enable GitHub Action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+      - run: make ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.10'
-      - run: make ci
+      - run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# Name of the cover profile
-COVER_PROFILE := cover.out
 # Disable go sum database lookup for private repos
 GOPRIVATE := github.com/onflow/*
 # Ensure go bin path is in path (especially for CI)
@@ -15,18 +13,7 @@ install-tools:
 
 .PHONY: test
 test:
-	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) ./...
-
-.PHONY: coverage
-coverage:
-ifeq ($(COVER), true)
-	# file has to be called index.html
-	gocov convert $(COVER_PROFILE) > cover.json
-	./cover-summary.sh
-	gocov-html cover.json > index.html
-	# coverage.zip will automatically be picked up by teamcity
-	gozip -c coverage.zip index.html
-endif
+	GO111MODULE=on go test -coverprofile=cover.out ./...
 
 .PHONY: generate-mocks
 generate-mocks:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 # Name of the cover profile
 COVER_PROFILE := cover.out
 # Disable go sum database lookup for private repos
-GOPRIVATE := github.com/dapperlabs/*
-# Ensure go bin path is in path (Especially for CI)
+GOPRIVATE := github.com/onflow/*
+# Ensure go bin path is in path (especially for CI)
 PATH := $(PATH):$(GOPATH)/bin
 
-BINARY ?= ./cmd/flow/flow
-
 .PHONY: install-tools
-install-tools: check-go-version
+install-tools:
 	cd ${GOPATH}; \
 	GO111MODULE=on go get github.com/vektra/mockery/cmd/mockery@v0.0.0-20181123154057-e78b021dcbb5; \
 	GO111MODULE=on go get github.com/axw/gocov/gocov; \
@@ -36,8 +34,3 @@ generate-mocks:
 
 .PHONY: ci
 ci: install-tools generate-mocks test coverage
-
-# Check if the go version is >1.13. flow-go-sdk only supports go versions > 1.13
-.PHONY: check-go-version
-check-go-version:
-	go version | grep '1.13\|1.14'

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,12 @@ ifeq ($(COVER), true)
 	gozip -c coverage.zip index.html
 endif
 
-.PHONY: generate
-generate: generate-mocks
-
 .PHONY: generate-mocks
 generate-mocks:
 	GO111MODULE=on mockery -name RPCClient -dir=client -case=underscore -output="./client/mocks" -outpkg="mocks"
 
 .PHONY: ci
-ci: install-tools generate test coverage
+ci: install-tools generate-mocks test coverage
 
 # Check if the go version is >1.13. flow-go-sdk only supports go versions > 1.13
 .PHONY: check-go-version


### PR DESCRIPTION
GH Actions do not have permissions to pull our private go dependencies, so this will fail until we publish the `flow` and `cadence` repos.