### PR TITLE
Include account key IDs in protobuf messages

### DIFF
--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -358,6 +358,7 @@ func MessageToAccountKey(m *entities.AccountKey) (*flow.AccountKey, error) {
 	}
 
 	return &flow.AccountKey{
+		ID:             int(m.GetIndex()),
 		PublicKey:      publicKey,
 		SigAlgo:        sigAlgo,
 		HashAlgo:       hashAlgo,
@@ -370,6 +371,7 @@ func AccountKeyToMessage(a *flow.AccountKey) (*entities.AccountKey, error) {
 	publicKey := a.PublicKey.Encode()
 
 	return &entities.AccountKey{
+		Index:          uint32(a.ID),
 		PublicKey:      publicKey,
 		SignAlgo:       uint32(a.SigAlgo),
 		HashAlgo:       uint32(a.HashAlgo),

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -72,3 +72,15 @@ func TestConvert_Event(t *testing.T) {
 
 	assert.Equal(t, eventA, eventB)
 }
+
+func TestConvert_AccountKey(t *testing.T) {
+	keyA := test.AccountKeyGenerator().New()
+
+	msg, err := convert.AccountKeyToMessage(keyA)
+	require.NoError(t, err)
+
+	keyB, err := convert.MessageToAccountKey(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, keyA, keyB)
+}


### PR DESCRIPTION
Ref: https://github.com/dapperlabs/flow-emulator/issues/46

## Description

Account key IDs were being omitted from protobuf messages. This PR fixes the `convert` package to include them.
