### PR TITLE
Client: Clean up unit tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -36,6 +36,25 @@ import (
 	"github.com/onflow/flow-go-sdk/test"
 )
 
+func TestClient_Ping(t *testing.T) {
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		response := &access.PingResponse{}
+
+		rpc.On("Ping", ctx, mock.Anything).Return(response, nil)
+
+		err := c.Ping(ctx)
+		assert.NoError(t, err)
+	}))
+
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		rpc.On("Ping", ctx, mock.Anything).
+			Return(nil, errors.New("rpc error"))
+
+		err := c.Ping(ctx)
+		assert.Error(t, err)
+	}))
+}
+
 func TestClient_GetLatestBlockHeader(t *testing.T) {
 	blocks := test.BlockGenerator()
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/onflow/flow-go-sdk/test"
 )
 
+var mockRPCError = errors.New("rpc error")
+
 func TestClient_Ping(t *testing.T) {
 	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		response := &access.PingResponse{}
@@ -48,7 +50,7 @@ func TestClient_Ping(t *testing.T) {
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("Ping", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		err := c.Ping(ctx)
 		assert.Error(t, err)
@@ -75,7 +77,7 @@ func TestClient_GetLatestBlockHeader(t *testing.T) {
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetLatestBlockHeader", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetLatestBlockHeader(ctx, true)
 		assert.Error(t, err)
@@ -106,7 +108,7 @@ func TestClient_GetBlockHeaderByID(t *testing.T) {
 		blockID := ids.New()
 
 		rpc.On("GetBlockHeaderByID", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetBlockHeaderByID(ctx, blockID)
 		assert.Error(t, err)
@@ -133,7 +135,7 @@ func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetBlockHeaderByHeight", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetBlockHeaderByHeight(ctx, 42)
 		assert.Error(t, err)
@@ -160,7 +162,7 @@ func TestClient_GetLatestBlock(t *testing.T) {
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetLatestBlock", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetLatestBlock(ctx, true)
 		assert.Error(t, err)
@@ -191,7 +193,7 @@ func TestClient_GetBlockByID(t *testing.T) {
 		blockID := ids.New()
 
 		rpc.On("GetBlockByID", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetBlockByID(ctx, blockID)
 		assert.Error(t, err)
@@ -218,7 +220,7 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetBlockByHeight(ctx, 42)
 		assert.Error(t, err)
@@ -249,7 +251,7 @@ func TestClient_GetCollection(t *testing.T) {
 		colID := ids.New()
 
 		rpc.On("GetCollectionByID", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetCollection(ctx, colID)
 		assert.Error(t, err)
@@ -277,7 +279,7 @@ func TestClient_SendTransaction(t *testing.T) {
 		tx := transactions.New()
 
 		rpc.On("SendTransaction", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		err := c.SendTransaction(ctx, *tx)
 		assert.Error(t, err)
@@ -307,7 +309,7 @@ func TestClient_GetTransaction(t *testing.T) {
 		txID := ids.New()
 
 		rpc.On("GetTransaction", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetTransaction(ctx, txID)
 		assert.Error(t, err)
@@ -337,7 +339,7 @@ func TestClient_GetTransactionResult(t *testing.T) {
 		txID := ids.New()
 
 		rpc.On("GetTransactionResult", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		result, err := c.GetTransactionResult(ctx, txID)
 		assert.Error(t, err)
@@ -426,7 +428,7 @@ func TestClient_GetEventsForHeightRange(t *testing.T) {
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetEventsForHeightRange", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		blocks, err := c.GetEventsForHeightRange(ctx, client.EventRangeQuery{
 			Type:        "foo",
@@ -509,8 +511,6 @@ func TestClient_GetEventsForBlockIDs(t *testing.T) {
 			assert.Equal(t, eventB, blocks[0].Events[1])
 			assert.Equal(t, eventC, blocks[1].Events[0])
 			assert.Equal(t, eventD, blocks[1].Events[1])
-
-			rpc.AssertExpectations(t)
 		}),
 	)
 
@@ -518,7 +518,7 @@ func TestClient_GetEventsForBlockIDs(t *testing.T) {
 		blockIDA, blockIDB := ids.New(), ids.New()
 
 		rpc.On("GetEventsForBlockIDs", ctx, mock.Anything).
-			Return(nil, errors.New("rpc error"))
+			Return(nil, mockRPCError)
 
 		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", []flow.Identifier{blockIDA, blockIDB})
 		assert.Error(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -347,6 +347,36 @@ func TestClient_GetTransactionResult(t *testing.T) {
 	}))
 }
 
+func TestClient_GetAccount(t *testing.T) {
+	accounts := test.AccountGenerator()
+	addresses := test.AddressGenerator()
+
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		expectedAccount := accounts.New()
+		response := &access.GetAccountResponse{
+			Account: convert.AccountToMessage(*expectedAccount),
+		}
+
+		rpc.On("GetAccount", ctx, mock.Anything).Return(response, nil)
+
+		account, err := c.GetAccount(ctx, expectedAccount.Address)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedAccount, account)
+	}))
+
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		address := addresses.New()
+
+		rpc.On("GetAccount", ctx, mock.Anything).
+			Return(nil, mockRPCError)
+
+		account, err := c.GetAccount(ctx, address)
+		assert.Error(t, err)
+		assert.Nil(t, account)
+	}))
+}
+
 func TestClient_GetEventsForHeightRange(t *testing.T) {
 	ids := test.IdentifierGenerator()
 	events := test.EventGenerator()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -39,56 +39,36 @@ import (
 func TestClient_GetLatestBlockHeader(t *testing.T) {
 	blocks := test.BlockGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		expectedHeader := blocks.New().BlockHeader
+
 		response := &access.BlockHeaderResponse{
 			Block: convert.BlockHeaderToMessage(expectedHeader),
 		}
 
 		rpc.On("GetLatestBlockHeader", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		header, err := c.GetLatestBlockHeader(ctx, true)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetLatestBlockHeader", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetLatestBlockHeader(ctx, true)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetBlockHeaderByID(t *testing.T) {
 	blocks := test.BlockGenerator()
 	ids := test.IdentifierGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		blockID := ids.New()
 		expectedHeader := blocks.New().BlockHeader
 		response := &access.BlockHeaderResponse{
@@ -97,45 +77,28 @@ func TestClient_GetBlockHeaderByID(t *testing.T) {
 
 		rpc.On("GetBlockHeaderByID", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		header, err := c.GetBlockHeaderByID(ctx, blockID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		blockID := ids.New()
 
 		rpc.On("GetBlockHeaderByID", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetBlockHeaderByID(ctx, blockID)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 	blocks := test.BlockGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		expectedHeader := blocks.New().BlockHeader
 		response := &access.BlockHeaderResponse{
 			Block: convert.BlockHeaderToMessage(expectedHeader),
@@ -143,43 +106,26 @@ func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 
 		rpc.On("GetBlockHeaderByHeight", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		header, err := c.GetBlockHeaderByHeight(ctx, 42)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetBlockHeaderByHeight", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetBlockHeaderByHeight(ctx, 42)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetLatestBlock(t *testing.T) {
 	blocks := test.BlockGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		expectedBlock := blocks.New()
 		response := &access.BlockResponse{
 			Block: convert.BlockToMessage(*expectedBlock),
@@ -187,44 +133,27 @@ func TestClient_GetLatestBlock(t *testing.T) {
 
 		rpc.On("GetLatestBlock", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		block, err := c.GetLatestBlock(ctx, true)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetLatestBlock", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetLatestBlock(ctx, true)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetBlockByID(t *testing.T) {
 	blocks := test.BlockGenerator()
 	ids := test.IdentifierGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		blockID := ids.New()
 		expectedBlock := blocks.New()
 		response := &access.BlockResponse{
@@ -233,45 +162,28 @@ func TestClient_GetBlockByID(t *testing.T) {
 
 		rpc.On("GetBlockByID", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		block, err := c.GetBlockByID(ctx, blockID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		blockID := ids.New()
 
 		rpc.On("GetBlockByID", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetBlockByID(ctx, blockID)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetBlockByHeight(t *testing.T) {
 	blocks := test.BlockGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		expectedBlock := blocks.New()
 		response := &access.BlockResponse{
 			Block: convert.BlockToMessage(*expectedBlock),
@@ -279,44 +191,27 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		block, err := c.GetBlockByHeight(ctx, 42)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetBlockByHeight(ctx, 42)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetCollection(t *testing.T) {
 	cols := test.CollectionGenerator()
 	ids := test.IdentifierGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		colID := ids.New()
 		expectedCol := cols.New()
 		response := &access.CollectionResponse{
@@ -325,45 +220,28 @@ func TestClient_GetCollection(t *testing.T) {
 
 		rpc.On("GetCollectionByID", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		col, err := c.GetCollection(ctx, colID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedCol, col)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		colID := ids.New()
 
 		rpc.On("GetCollectionByID", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetCollection(ctx, colID)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_SendTransaction(t *testing.T) {
 	transactions := test.TransactionGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		tx := transactions.New()
 
 		response := &access.SendTransactionResponse{
@@ -372,42 +250,26 @@ func TestClient_SendTransaction(t *testing.T) {
 
 		rpc.On("SendTransaction", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		err := c.SendTransaction(ctx, *tx)
 		require.NoError(t, err)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		tx := transactions.New()
 
 		rpc.On("SendTransaction", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		err := c.SendTransaction(ctx, *tx)
-		require.NoError(t, err)
-
-		rpc.AssertExpectations(t)
-	})
+		assert.Error(t, err)
+	}))
 }
 
 func TestClient_GetTransaction(t *testing.T) {
 	txs := test.TransactionGenerator()
 	ids := test.IdentifierGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		txID := ids.New()
 		expectedTx := txs.New()
 		response := &access.TransactionResponse{
@@ -416,296 +278,243 @@ func TestClient_GetTransaction(t *testing.T) {
 
 		rpc.On("GetTransaction", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		tx, err := c.GetTransaction(ctx, txID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedTx, tx)
+	}))
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		txID := ids.New()
 
 		rpc.On("GetTransaction", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetTransaction(ctx, txID)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetTransactionResult(t *testing.T) {
 	results := test.TransactionResultGenerator()
 	ids := test.IdentifierGenerator()
 
-	t.Run("Success", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		txID := ids.New()
 		expectedResult := results.New()
 		response, _ := convert.TransactionResultToMessage(expectedResult)
 
 		rpc.On("GetTransactionResult", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetTransactionResult(ctx, txID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedResult, *result)
 
-		rpc.AssertExpectations(t)
-	})
+	}))
 
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		txID := ids.New()
 
 		rpc.On("GetTransactionResult", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		result, err := c.GetTransactionResult(ctx, txID)
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Nil(t, result)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetEventsForHeightRange(t *testing.T) {
 	ids := test.IdentifierGenerator()
 	events := test.EventGenerator()
 
-	t.Run("Empty result", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
+	t.Run(
+		"Empty result",
+		clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+			response := &access.EventsResponse{
+				Results: []*access.EventsResponse_Result{},
+			}
 
-		ctx := context.Background()
+			rpc.On("GetEventsForHeightRange", ctx, mock.Anything).Return(response, nil)
 
-		response := &access.EventsResponse{
-			Results: []*access.EventsResponse_Result{},
-		}
+			blocks, err := c.GetEventsForHeightRange(ctx, client.EventRangeQuery{
+				Type:        "foo",
+				StartHeight: 1,
+				EndHeight:   10,
+			})
+			require.NoError(t, err)
 
-		rpc.On("GetEventsForHeightRange", ctx, mock.Anything).Return(response, nil)
+			assert.Empty(t, blocks)
+		}),
+	)
 
-		c := client.NewFromRPCClient(rpc)
+	t.Run(
+		"Non-empty result",
+		clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+			eventA, eventB, eventC, eventD := events.New(), events.New(), events.New(), events.New()
 
-		blocks, err := c.GetEventsForHeightRange(ctx, client.EventRangeQuery{
-			Type:        "foo",
-			StartHeight: 1,
-			EndHeight:   10,
-		})
-		require.NoError(t, err)
+			eventAMsg, _ := convert.EventToMessage(eventA)
+			eventBMsg, _ := convert.EventToMessage(eventB)
+			eventCMsg, _ := convert.EventToMessage(eventC)
+			eventDMsg, _ := convert.EventToMessage(eventD)
 
-		assert.Empty(t, blocks)
-
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Non-empty result", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
-		eventA, eventB, eventC, eventD := events.New(), events.New(), events.New(), events.New()
-
-		eventAMsg, _ := convert.EventToMessage(eventA)
-		eventBMsg, _ := convert.EventToMessage(eventB)
-		eventCMsg, _ := convert.EventToMessage(eventC)
-		eventDMsg, _ := convert.EventToMessage(eventD)
-
-		response := &access.EventsResponse{
-			Results: []*access.EventsResponse_Result{
-				{
-					BlockId:     ids.New().Bytes(),
-					BlockHeight: 1,
-					Events: []*entities.Event{
-						eventAMsg,
-						eventBMsg,
+			response := &access.EventsResponse{
+				Results: []*access.EventsResponse_Result{
+					{
+						BlockId:     ids.New().Bytes(),
+						BlockHeight: 1,
+						Events: []*entities.Event{
+							eventAMsg,
+							eventBMsg,
+						},
+					},
+					{
+						BlockId:     ids.New().Bytes(),
+						BlockHeight: 2,
+						Events: []*entities.Event{
+							eventCMsg,
+							eventDMsg,
+						},
 					},
 				},
-				{
-					BlockId:     ids.New().Bytes(),
-					BlockHeight: 2,
-					Events: []*entities.Event{
-						eventCMsg,
-						eventDMsg,
-					},
-				},
-			},
-		}
+			}
 
-		rpc.On("GetEventsForHeightRange", ctx, mock.Anything).Return(response, nil)
+			rpc.On("GetEventsForHeightRange", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
+			blocks, err := c.GetEventsForHeightRange(ctx, client.EventRangeQuery{
+				Type:        "foo",
+				StartHeight: 1,
+				EndHeight:   10,
+			})
+			require.NoError(t, err)
 
-		blocks, err := c.GetEventsForHeightRange(ctx, client.EventRangeQuery{
-			Type:        "foo",
-			StartHeight: 1,
-			EndHeight:   10,
-		})
-		require.NoError(t, err)
+			assert.Len(t, blocks, len(response.Results))
 
-		assert.Len(t, blocks, len(response.Results))
+			assert.Equal(t, response.Results[0].BlockId, blocks[0].BlockID.Bytes())
+			assert.Equal(t, response.Results[0].BlockHeight, blocks[0].Height)
 
-		assert.Equal(t, response.Results[0].BlockId, blocks[0].BlockID.Bytes())
-		assert.Equal(t, response.Results[0].BlockHeight, blocks[0].Height)
+			assert.Equal(t, response.Results[1].BlockId, blocks[1].BlockID.Bytes())
+			assert.Equal(t, response.Results[1].BlockHeight, blocks[1].Height)
 
-		assert.Equal(t, response.Results[1].BlockId, blocks[1].BlockID.Bytes())
-		assert.Equal(t, response.Results[1].BlockHeight, blocks[1].Height)
+			assert.Equal(t, eventA, blocks[0].Events[0])
+			assert.Equal(t, eventB, blocks[0].Events[1])
+			assert.Equal(t, eventC, blocks[1].Events[0])
+			assert.Equal(t, eventD, blocks[1].Events[1])
+		}),
+	)
 
-		assert.Equal(t, eventA, blocks[0].Events[0])
-		assert.Equal(t, eventB, blocks[0].Events[1])
-		assert.Equal(t, eventC, blocks[1].Events[0])
-		assert.Equal(t, eventD, blocks[1].Events[1])
-
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		rpc.On("GetEventsForHeightRange", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		blocks, err := c.GetEventsForHeightRange(ctx, client.EventRangeQuery{
 			Type:        "foo",
 			StartHeight: 1,
 			EndHeight:   10,
 		})
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Empty(t, blocks)
-
-		rpc.AssertExpectations(t)
-	})
+	}))
 }
 
 func TestClient_GetEventsForBlockIDs(t *testing.T) {
 	ids := test.IdentifierGenerator()
 	events := test.EventGenerator()
 
-	t.Run("Empty result", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
+	t.Run(
+		"Empty result",
+		clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+			blockIDs := []flow.Identifier{ids.New(), ids.New()}
 
-		ctx := context.Background()
+			response := &access.EventsResponse{
+				Results: []*access.EventsResponse_Result{},
+			}
 
-		blockIDs := []flow.Identifier{ids.New(), ids.New()}
+			rpc.On("GetEventsForBlockIDs", ctx, mock.Anything).Return(response, nil)
 
-		response := &access.EventsResponse{
-			Results: []*access.EventsResponse_Result{},
-		}
+			blocks, err := c.GetEventsForBlockIDs(ctx, "foo", blockIDs)
+			require.NoError(t, err)
 
-		rpc.On("GetEventsForBlockIDs", ctx, mock.Anything).Return(response, nil)
+			assert.Empty(t, blocks)
+		}),
+	)
 
-		c := client.NewFromRPCClient(rpc)
+	t.Run(
+		"Non-empty result",
+		clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+			blockIDA, blockIDB := ids.New(), ids.New()
+			eventA, eventB, eventC, eventD := events.New(), events.New(), events.New(), events.New()
 
-		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", blockIDs)
-		require.NoError(t, err)
+			eventAMsg, _ := convert.EventToMessage(eventA)
+			eventBMsg, _ := convert.EventToMessage(eventB)
+			eventCMsg, _ := convert.EventToMessage(eventC)
+			eventDMsg, _ := convert.EventToMessage(eventD)
 
-		assert.Empty(t, blocks)
-
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Non-empty result", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
-		blockIDA, blockIDB := ids.New(), ids.New()
-		eventA, eventB, eventC, eventD := events.New(), events.New(), events.New(), events.New()
-
-		eventAMsg, _ := convert.EventToMessage(eventA)
-		eventBMsg, _ := convert.EventToMessage(eventB)
-		eventCMsg, _ := convert.EventToMessage(eventC)
-		eventDMsg, _ := convert.EventToMessage(eventD)
-
-		response := &access.EventsResponse{
-			Results: []*access.EventsResponse_Result{
-				{
-					BlockId:     blockIDA.Bytes(),
-					BlockHeight: 1,
-					Events: []*entities.Event{
-						eventAMsg,
-						eventBMsg,
+			response := &access.EventsResponse{
+				Results: []*access.EventsResponse_Result{
+					{
+						BlockId:     blockIDA.Bytes(),
+						BlockHeight: 1,
+						Events: []*entities.Event{
+							eventAMsg,
+							eventBMsg,
+						},
+					},
+					{
+						BlockId:     blockIDB.Bytes(),
+						BlockHeight: 2,
+						Events: []*entities.Event{
+							eventCMsg,
+							eventDMsg,
+						},
 					},
 				},
-				{
-					BlockId:     blockIDB.Bytes(),
-					BlockHeight: 2,
-					Events: []*entities.Event{
-						eventCMsg,
-						eventDMsg,
-					},
-				},
-			},
-		}
+			}
 
-		rpc.On("GetEventsForBlockIDs", ctx, mock.Anything).Return(response, nil)
+			rpc.On("GetEventsForBlockIDs", ctx, mock.Anything).Return(response, nil)
 
-		c := client.NewFromRPCClient(rpc)
+			blocks, err := c.GetEventsForBlockIDs(ctx, "foo", []flow.Identifier{blockIDA, blockIDB})
+			require.NoError(t, err)
 
-		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", []flow.Identifier{blockIDA, blockIDB})
-		require.NoError(t, err)
+			assert.Len(t, blocks, len(response.Results))
 
-		assert.Len(t, blocks, len(response.Results))
+			assert.Equal(t, response.Results[0].BlockId, blocks[0].BlockID.Bytes())
+			assert.Equal(t, response.Results[0].BlockHeight, blocks[0].Height)
 
-		assert.Equal(t, response.Results[0].BlockId, blocks[0].BlockID.Bytes())
-		assert.Equal(t, response.Results[0].BlockHeight, blocks[0].Height)
+			assert.Equal(t, response.Results[1].BlockId, blocks[1].BlockID.Bytes())
+			assert.Equal(t, response.Results[1].BlockHeight, blocks[1].Height)
 
-		assert.Equal(t, response.Results[1].BlockId, blocks[1].BlockID.Bytes())
-		assert.Equal(t, response.Results[1].BlockHeight, blocks[1].Height)
+			assert.Equal(t, eventA, blocks[0].Events[0])
+			assert.Equal(t, eventB, blocks[0].Events[1])
+			assert.Equal(t, eventC, blocks[1].Events[0])
+			assert.Equal(t, eventD, blocks[1].Events[1])
 
-		assert.Equal(t, eventA, blocks[0].Events[0])
-		assert.Equal(t, eventB, blocks[0].Events[1])
-		assert.Equal(t, eventC, blocks[1].Events[0])
-		assert.Equal(t, eventD, blocks[1].Events[1])
+			rpc.AssertExpectations(t)
+		}),
+	)
 
-		rpc.AssertExpectations(t)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		rpc := &mocks.RPCClient{}
-
-		ctx := context.Background()
-
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		blockIDA, blockIDB := ids.New(), ids.New()
 
 		rpc.On("GetEventsForBlockIDs", ctx, mock.Anything).
 			Return(nil, errors.New("rpc error"))
 
-		c := client.NewFromRPCClient(rpc)
-
 		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", []flow.Identifier{blockIDA, blockIDB})
-		require.NoError(t, err)
-
+		assert.Error(t, err)
 		assert.Empty(t, blocks)
+	}))
+}
 
+func clientTest(
+	f func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, client *client.Client),
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		rpc := &mocks.RPCClient{}
+		c := client.NewFromRPCClient(rpc)
+		f(t, ctx, rpc, c)
 		rpc.AssertExpectations(t)
-	})
+	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/flow/protobuf/go/flow/entities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
@@ -53,7 +54,7 @@ func TestClient_GetLatestBlockHeader(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		header, err := c.GetLatestBlockHeader(ctx, true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
 
@@ -71,7 +72,8 @@ func TestClient_GetLatestBlockHeader(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetLatestBlockHeader(ctx, true)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -98,7 +100,7 @@ func TestClient_GetBlockHeaderByID(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		header, err := c.GetBlockHeaderByID(ctx, blockID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
 
@@ -118,7 +120,8 @@ func TestClient_GetBlockHeaderByID(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetBlockHeaderByID(ctx, blockID)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -143,7 +146,7 @@ func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		header, err := c.GetBlockHeaderByHeight(ctx, 42)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
 
@@ -161,7 +164,8 @@ func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetBlockHeaderByHeight(ctx, 42)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -186,7 +190,7 @@ func TestClient_GetLatestBlock(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		block, err := c.GetLatestBlock(ctx, true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
 
@@ -204,7 +208,8 @@ func TestClient_GetLatestBlock(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetLatestBlock(ctx, true)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -231,7 +236,7 @@ func TestClient_GetBlockByID(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		block, err := c.GetBlockByID(ctx, blockID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
 
@@ -251,7 +256,8 @@ func TestClient_GetBlockByID(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetBlockByID(ctx, blockID)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -276,7 +282,7 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		block, err := c.GetBlockByHeight(ctx, 42)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
 
@@ -294,7 +300,8 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetBlockByHeight(ctx, 42)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -321,7 +328,7 @@ func TestClient_GetCollection(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		col, err := c.GetCollection(ctx, colID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedCol, col)
 
@@ -341,7 +348,8 @@ func TestClient_GetCollection(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetCollection(ctx, colID)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -367,8 +375,7 @@ func TestClient_SendTransaction(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		err := c.SendTransaction(ctx, *tx)
-
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		rpc.AssertExpectations(t)
 	})
@@ -386,7 +393,7 @@ func TestClient_SendTransaction(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		err := c.SendTransaction(ctx, *tx)
-		assert.Error(t, err)
+		require.NoError(t, err)
 
 		rpc.AssertExpectations(t)
 	})
@@ -412,7 +419,7 @@ func TestClient_GetTransaction(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		tx, err := c.GetTransaction(ctx, txID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedTx, tx)
 
@@ -432,7 +439,8 @@ func TestClient_GetTransaction(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetTransaction(ctx, txID)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -457,7 +465,7 @@ func TestClient_GetTransactionResult(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetTransactionResult(ctx, txID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, expectedResult, *result)
 
@@ -477,7 +485,8 @@ func TestClient_GetTransactionResult(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		result, err := c.GetTransactionResult(ctx, txID)
-		assert.Error(t, err)
+		require.NoError(t, err)
+
 		assert.Nil(t, result)
 
 		rpc.AssertExpectations(t)
@@ -506,7 +515,7 @@ func TestClient_GetEventsForHeightRange(t *testing.T) {
 			StartHeight: 1,
 			EndHeight:   10,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Empty(t, blocks)
 
@@ -555,7 +564,7 @@ func TestClient_GetEventsForHeightRange(t *testing.T) {
 			StartHeight: 1,
 			EndHeight:   10,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, blocks, len(response.Results))
 
@@ -588,8 +597,8 @@ func TestClient_GetEventsForHeightRange(t *testing.T) {
 			StartHeight: 1,
 			EndHeight:   10,
 		})
+		require.NoError(t, err)
 
-		assert.Error(t, err)
 		assert.Empty(t, blocks)
 
 		rpc.AssertExpectations(t)
@@ -616,7 +625,7 @@ func TestClient_GetEventsForBlockIDs(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", blockIDs)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Empty(t, blocks)
 
@@ -662,7 +671,7 @@ func TestClient_GetEventsForBlockIDs(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", []flow.Identifier{blockIDA, blockIDB})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, blocks, len(response.Results))
 
@@ -693,8 +702,8 @@ func TestClient_GetEventsForBlockIDs(t *testing.T) {
 		c := client.NewFromRPCClient(rpc)
 
 		blocks, err := c.GetEventsForBlockIDs(ctx, "foo", []flow.Identifier{blockIDA, blockIDB})
+		require.NoError(t, err)
 
-		assert.Error(t, err)
 		assert.Empty(t, blocks)
 
 		rpc.AssertExpectations(t)

--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -326,14 +326,10 @@ func MessageToAccount(m *entities.Account) (flow.Account, error) {
 	}, nil
 }
 
-func AccountToMessage(a flow.Account) (*entities.Account, error) {
+func AccountToMessage(a flow.Account) *entities.Account {
 	accountKeys := make([]*entities.AccountKey, len(a.Keys))
 	for i, key := range a.Keys {
-		accountKeyMsg, err := AccountKeyToMessage(key)
-		if err != nil {
-			return nil, err
-		}
-		accountKeys[i] = accountKeyMsg
+		accountKeys[i] = AccountKeyToMessage(key)
 	}
 
 	return &entities.Account{
@@ -341,7 +337,7 @@ func AccountToMessage(a flow.Account) (*entities.Account, error) {
 		Balance: a.Balance,
 		Code:    a.Code,
 		Keys:    accountKeys,
-	}, nil
+	}
 }
 
 func MessageToAccountKey(m *entities.AccountKey) (*flow.AccountKey, error) {
@@ -367,17 +363,15 @@ func MessageToAccountKey(m *entities.AccountKey) (*flow.AccountKey, error) {
 	}, nil
 }
 
-func AccountKeyToMessage(a *flow.AccountKey) (*entities.AccountKey, error) {
-	publicKey := a.PublicKey.Encode()
-
+func AccountKeyToMessage(a *flow.AccountKey) *entities.AccountKey {
 	return &entities.AccountKey{
 		Index:          uint32(a.ID),
-		PublicKey:      publicKey,
+		PublicKey:      a.PublicKey.Encode(),
 		SignAlgo:       uint32(a.SigAlgo),
 		HashAlgo:       uint32(a.HashAlgo),
 		Weight:         uint32(a.Weight),
 		SequenceNumber: uint32(a.SequenceNumber),
-	}, nil
+	}
 }
 
 func MessageToEvent(m *entities.Event) (flow.Event, error) {

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -34,8 +34,8 @@ func TestConvert_Block(t *testing.T) {
 	msg := convert.BlockToMessage(*blockA)
 
 	blockB, err := convert.MessageToBlock(msg)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
 	assert.Equal(t, *blockA, blockB)
 }
 
@@ -45,8 +45,8 @@ func TestConvert_Collection(t *testing.T) {
 	msg := convert.CollectionToMessage(*colA)
 
 	colB, err := convert.MessageToCollection(msg)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
 	assert.Equal(t, *colA, colB)
 }
 
@@ -56,8 +56,8 @@ func TestConvert_Transaction(t *testing.T) {
 	msg := convert.TransactionToMessage(*txA)
 
 	txB, err := convert.MessageToTransaction(msg)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
 	assert.Equal(t, txA.ID(), txB.ID())
 }
 
@@ -76,8 +76,7 @@ func TestConvert_Event(t *testing.T) {
 func TestConvert_AccountKey(t *testing.T) {
 	keyA := test.AccountKeyGenerator().New()
 
-	msg, err := convert.AccountKeyToMessage(keyA)
-	require.NoError(t, err)
+	msg := convert.AccountKeyToMessage(keyA)
 
 	keyB, err := convert.MessageToAccountKey(msg)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR cleans up and refactors unit tests for the `client` package.

- Add `clientTest` helper to consolidate common test setup
- Replace `assert` with `require` in cases where test will halt if error occurs
- Add test cases for `Ping`, `GetAccount` and `ExecuteScriptAtLatestBlock`
