### PR TITLE
Client: Add ExecuteScriptAtBlockID, ExecuteScriptAtBlockHeight

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -422,6 +422,94 @@ func TestClient_ExecuteScriptAtLatestBlock(t *testing.T) {
 	}))
 }
 
+func TestClient_ExecuteScriptAtBlockID(t *testing.T) {
+	ids := test.IdentifierGenerator()
+
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		expectedValue := cadence.NewInt(42)
+		encodedValue, err := jsoncdc.Encode(expectedValue)
+		require.NoError(t, err)
+
+		response := &access.ExecuteScriptResponse{
+			Value: encodedValue,
+		}
+
+		rpc.On("ExecuteScriptAtBlockID", ctx, mock.Anything).Return(response, nil)
+
+		value, err := c.ExecuteScriptAtBlockID(ctx, ids.New(), []byte("foo"))
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedValue, value)
+	}))
+
+	t.Run(
+		"Invalid JSON-CDC",
+		clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+			response := &access.ExecuteScriptResponse{
+				Value: []byte("invalid JSON-CDC bytes"),
+			}
+
+			rpc.On("ExecuteScriptAtBlockID", ctx, mock.Anything).Return(response, nil)
+
+			value, err := c.ExecuteScriptAtBlockID(ctx, ids.New(), []byte("foo"))
+			assert.Error(t, err)
+			assert.Nil(t, value)
+		}),
+	)
+
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		rpc.On("ExecuteScriptAtBlockID", ctx, mock.Anything).
+			Return(nil, mockRPCError)
+
+		value, err := c.ExecuteScriptAtBlockID(ctx, ids.New(), []byte("foo"))
+		assert.Error(t, err)
+		assert.Nil(t, value)
+	}))
+}
+
+func TestClient_ExecuteScriptAtBlockHeight(t *testing.T) {
+	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		expectedValue := cadence.NewInt(42)
+		encodedValue, err := jsoncdc.Encode(expectedValue)
+		require.NoError(t, err)
+
+		response := &access.ExecuteScriptResponse{
+			Value: encodedValue,
+		}
+
+		rpc.On("ExecuteScriptAtBlockHeight", ctx, mock.Anything).Return(response, nil)
+
+		value, err := c.ExecuteScriptAtBlockHeight(ctx, 42, []byte("foo"))
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedValue, value)
+	}))
+
+	t.Run(
+		"Invalid JSON-CDC",
+		clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+			response := &access.ExecuteScriptResponse{
+				Value: []byte("invalid JSON-CDC bytes"),
+			}
+
+			rpc.On("ExecuteScriptAtBlockHeight", ctx, mock.Anything).Return(response, nil)
+
+			value, err := c.ExecuteScriptAtBlockHeight(ctx, 42, []byte("foo"))
+			assert.Error(t, err)
+			assert.Nil(t, value)
+		}),
+	)
+
+	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
+		rpc.On("ExecuteScriptAtBlockHeight", ctx, mock.Anything).
+			Return(nil, mockRPCError)
+
+		value, err := c.ExecuteScriptAtBlockHeight(ctx, 42, []byte("foo"))
+		assert.Error(t, err)
+		assert.Nil(t, value)
+	}))
+}
+
 func TestClient_GetEventsForHeightRange(t *testing.T) {
 	ids := test.IdentifierGenerator()
 	events := test.EventGenerator()

--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -375,9 +375,9 @@ func AccountKeyToMessage(a *flow.AccountKey) *entities.AccountKey {
 }
 
 func MessageToEvent(m *entities.Event) (flow.Event, error) {
-	value, err := jsoncdc.Decode(m.GetPayload())
+	value, err := MessageToCadenceValue(m.GetPayload())
 	if err != nil {
-		return flow.Event{}, nil
+		return flow.Event{}, err
 	}
 
 	eventValue, isEvent := value.(cadence.Event)
@@ -395,9 +395,9 @@ func MessageToEvent(m *entities.Event) (flow.Event, error) {
 }
 
 func EventToMessage(e flow.Event) (*entities.Event, error) {
-	payload, err := jsoncdc.Encode(e.Value)
+	payload, err := CadenceValueToMessage(e.Value)
 	if err != nil {
-		return nil, fmt.Errorf("convert: %w", err)
+		return nil, err
 	}
 
 	return &entities.Event{
@@ -407,4 +407,22 @@ func EventToMessage(e flow.Event) (*entities.Event, error) {
 		EventIndex:       uint32(e.EventIndex),
 		Payload:          payload,
 	}, nil
+}
+
+func CadenceValueToMessage(value cadence.Value) ([]byte, error) {
+	b, err := jsoncdc.Encode(value)
+	if err != nil {
+		return nil, fmt.Errorf("convert: %w", err)
+	}
+
+	return b, nil
+}
+
+func MessageToCadenceValue(m []byte) (cadence.Value, error) {
+	v, err := jsoncdc.Decode(m)
+	if err != nil {
+		return nil, fmt.Errorf("convert: %w", err)
+	}
+
+	return v, nil
 }

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -21,6 +21,7 @@ package convert_test
 import (
 	"testing"
 
+	"github.com/onflow/cadence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -82,4 +83,26 @@ func TestConvert_AccountKey(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, keyA, keyB)
+}
+
+func TestConvert_CadenceValue(t *testing.T) {
+	t.Run("Valid value", func(t *testing.T) {
+		valueA := cadence.NewInt(42)
+
+		msg, err := convert.CadenceValueToMessage(valueA)
+		require.NoError(t, err)
+
+		valueB, err := convert.MessageToCadenceValue(msg)
+		require.NoError(t, err)
+
+		assert.Equal(t, valueA, valueB)
+	})
+
+	t.Run("Invalid message", func(t *testing.T) {
+		msg := []byte("invalid JSON-CDC bytes")
+
+		value, err := convert.MessageToCadenceValue(msg)
+		assert.Error(t, err)
+		assert.Nil(t, value)
+	})
 }


### PR DESCRIPTION
⚠️ Depends on #25 

## Description

This PR implements the remaining `ExecuteScript` methods on the `client.Client` struct.

- Implement `ExecuteScriptAtBlockID`
- Implement `ExecuteScriptAtBlockHeight`
- Add `convert.CadenceValueToMessage` and `convert.MessageToCadenceValue` functions
