### PR TITLE
Client: Convert test cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# Disable go sum database lookup for private repos
-GOPRIVATE := github.com/onflow/*
 # Ensure go bin path is in path (especially for CI)
 PATH := $(PATH):$(GOPATH)/bin
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ install-tools:
 test:
 	GO111MODULE=on go test -coverprofile=cover.out ./...
 
+.PHONY: coverage
+coverage: test
+	go tool cover -html=cover.out
+
 .PHONY: generate-mocks
 generate-mocks:
 	GO111MODULE=on mockery -name RPCClient -dir=client -case=underscore -output="./client/mocks" -outpkg="mocks"

--- a/client/client.go
+++ b/client/client.go
@@ -399,7 +399,7 @@ func (c *Client) GetEventsForBlockIDs(
 ) ([]BlockEvents, error) {
 	req := &access.GetEventsForBlockIDsRequest{
 		Type:     eventType,
-		BlockIds: convert.IDsToMessages(blockIDs),
+		BlockIds: convert.IdentifiersToMessages(blockIDs),
 	}
 
 	res, err := c.rpcClient.GetEventsForBlockIDs(ctx, req)

--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -52,8 +52,8 @@ func MessageToAccount(m *entities.Account) (flow.Account, error) {
 		return flow.Account{}, ErrEmptyMessage
 	}
 
-	accountKeys := make([]*flow.AccountKey, len(m.Keys))
-	for i, key := range m.Keys {
+	accountKeys := make([]*flow.AccountKey, len(m.GetKeys()))
+	for i, key := range m.GetKeys() {
 		accountKey, err := MessageToAccountKey(key)
 		if err != nil {
 			return flow.Account{}, err
@@ -63,9 +63,9 @@ func MessageToAccount(m *entities.Account) (flow.Account, error) {
 	}
 
 	return flow.Account{
-		Address: flow.BytesToAddress(m.Address),
-		Balance: m.Balance,
-		Code:    m.Code,
+		Address: flow.BytesToAddress(m.GetAddress()),
+		Balance: m.GetBalance(),
+		Code:    m.GetCode(),
 		Keys:    accountKeys,
 	}, nil
 }

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -25,9 +25,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client/convert"
 	"github.com/onflow/flow-go-sdk/test"
 )
+
+func TestConvert_Account(t *testing.T) {
+	accountA := test.AccountGenerator().New()
+
+	msg := convert.AccountToMessage(*accountA)
+
+	accountB, err := convert.MessageToAccount(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, *accountA, accountB)
+}
+
+func TestConvert_AccountKey(t *testing.T) {
+	keyA := test.AccountKeyGenerator().New()
+
+	msg := convert.AccountKeyToMessage(keyA)
+
+	keyB, err := convert.MessageToAccountKey(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, keyA, keyB)
+}
 
 func TestConvert_Block(t *testing.T) {
 	blockA := test.BlockGenerator().New()
@@ -40,49 +63,15 @@ func TestConvert_Block(t *testing.T) {
 	assert.Equal(t, *blockA, blockB)
 }
 
-func TestConvert_Collection(t *testing.T) {
-	colA := test.CollectionGenerator().New()
+func TestConvert_BlockHeader(t *testing.T) {
+	headerA := test.BlockHeaderGenerator().New()
 
-	msg := convert.CollectionToMessage(*colA)
+	msg := convert.BlockHeaderToMessage(headerA)
 
-	colB, err := convert.MessageToCollection(msg)
+	headerB, err := convert.MessageToBlockHeader(msg)
 	require.NoError(t, err)
 
-	assert.Equal(t, *colA, colB)
-}
-
-func TestConvert_Transaction(t *testing.T) {
-	txA := test.TransactionGenerator().New()
-
-	msg := convert.TransactionToMessage(*txA)
-
-	txB, err := convert.MessageToTransaction(msg)
-	require.NoError(t, err)
-
-	assert.Equal(t, txA.ID(), txB.ID())
-}
-
-func TestConvert_Event(t *testing.T) {
-	eventA := test.EventGenerator().New()
-
-	msg, err := convert.EventToMessage(eventA)
-	require.NoError(t, err)
-
-	eventB, err := convert.MessageToEvent(msg)
-	require.NoError(t, err)
-
-	assert.Equal(t, eventA, eventB)
-}
-
-func TestConvert_AccountKey(t *testing.T) {
-	keyA := test.AccountKeyGenerator().New()
-
-	msg := convert.AccountKeyToMessage(keyA)
-
-	keyB, err := convert.MessageToAccountKey(msg)
-	require.NoError(t, err)
-
-	assert.Equal(t, keyA, keyB)
+	assert.Equal(t, headerA, headerB)
 }
 
 func TestConvert_CadenceValue(t *testing.T) {
@@ -105,4 +94,101 @@ func TestConvert_CadenceValue(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, value)
 	})
+}
+
+func TestConvert_Collection(t *testing.T) {
+	colA := test.CollectionGenerator().New()
+
+	msg := convert.CollectionToMessage(*colA)
+
+	colB, err := convert.MessageToCollection(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, *colA, colB)
+}
+
+func TestConvert_CollectionGuarantee(t *testing.T) {
+	cgA := test.CollectionGuaranteeGenerator().New()
+
+	msg := convert.CollectionGuaranteeToMessage(*cgA)
+
+	cgB, err := convert.MessageToCollectionGuarantee(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, *cgA, cgB)
+}
+
+func TestConvert_CollectionGuarantees(t *testing.T) {
+	cgs := test.CollectionGuaranteeGenerator()
+
+	cgsA := []*flow.CollectionGuarantee{
+		cgs.New(),
+		cgs.New(),
+		cgs.New(),
+	}
+
+	msg := convert.CollectionGuaranteesToMessages(cgsA)
+
+	cgsB, err := convert.MessagesToCollectionGuarantees(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, cgsA, cgsB)
+}
+
+func TestConvert_Event(t *testing.T) {
+	eventA := test.EventGenerator().New()
+
+	msg, err := convert.EventToMessage(eventA)
+	require.NoError(t, err)
+
+	eventB, err := convert.MessageToEvent(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, eventA, eventB)
+}
+
+func TestConvert_Identifier(t *testing.T) {
+	idA := test.IdentifierGenerator().New()
+
+	msg := convert.IdentifierToMessage(idA)
+	idB := convert.MessageToIdentifier(msg)
+
+	assert.Equal(t, idA, idB)
+}
+
+func TestConvert_Identifiers(t *testing.T) {
+	ids := test.IdentifierGenerator()
+
+	idsA := []flow.Identifier{
+		ids.New(),
+		ids.New(),
+		ids.New(),
+	}
+
+	msg := convert.IdentifiersToMessages(idsA)
+	idsB := convert.MessagesToIdentifiers(msg)
+
+	assert.Equal(t, idsA, idsB)
+}
+
+func TestConvert_Transaction(t *testing.T) {
+	txA := test.TransactionGenerator().New()
+
+	msg := convert.TransactionToMessage(*txA)
+
+	txB, err := convert.MessageToTransaction(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, txA.ID(), txB.ID())
+}
+
+func TestConvert_TransactionResult(t *testing.T) {
+	resultA := test.TransactionResultGenerator().New()
+
+	msg, err := convert.TransactionResultToMessage(resultA)
+
+	resultB, err := convert.MessageToTransactionResult(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, resultA, resultB)
 }


### PR DESCRIPTION
Depends on #26

## Description

This PR cleans up the unit tests for the `client/convert` package.

- Sort all `convert` functions alphabetically
- Sort all `test` generators alphabetically
- Add test cases for:
  - `AccountToMessage`, `MessageToAccount`
  - `BlockHeaderToMessage`, `MessageToBlockHeader`
  - `CollectionGuaranteeToMessage`, `MessageToCollectionGuarantee`
  - `CollectionGuaranteesToMessages`, `MessagesToCollectionGuarantees`
  - `IdentifierToMessage`, `MessageToIdentifier`
  - `IdentifiersToMessages`, `MessagesToIdentifiers`
- Add `coverage` target to Makefile that displays test coverage stats

