### PR TITLE
Upgrade Cadence to v0.3.0-beta1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/lithammer/dedent v1.1.0
 	github.com/magiconair/properties v1.8.1
-	github.com/onflow/cadence v0.2.2-0.20200519193421-35ba64705ea5
+	github.com/onflow/cadence v0.3.0-beta1
 	github.com/onflow/flow/protobuf/go/flow v0.1.4
 	github.com/pkg/errors v0.8.1
 	github.com/segmentio/fasthash v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/onflow/cadence v0.2.2-0.20200519193421-35ba64705ea5 h1:QEZAA0yzYqypRHHPPlgt5XRR8YEcTmoOGweJKLTjQ3s=
-github.com/onflow/cadence v0.2.2-0.20200519193421-35ba64705ea5/go.mod h1:GaLQ7IsJi5bqpH66GprNs8uoQtperK/xbXXIOq11nZw=
+github.com/onflow/cadence v0.3.0-beta1 h1:hvCoaDfGRCWbS+M6S+5uyh9CRjd7uGJvOtuPB4oYrh4=
+github.com/onflow/cadence v0.3.0-beta1/go.mod h1:GaLQ7IsJi5bqpH66GprNs8uoQtperK/xbXXIOq11nZw=
 github.com/onflow/flow/protobuf/go/flow v0.1.4 h1:xRdLYCxR/V6lq03ElK3g0T/F8pCIpLrKs2IHQTYr9rM=
 github.com/onflow/flow/protobuf/go/flow v0.1.4/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
## Description

Bump `onflow/cadence` version to `v0.3.0-beta1`.