### PR TITLE
Update the account address generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ if err != nil {
     panic("failed to connect to emulator")
 }
 
-payer, payerKey, payerSigner := examples.RootAccount(c)
+payer, payerKey, payerSigner := examples.ServiceAccount(c)
 
 tx := flow.NewTransaction().
     SetScript(script).

--- a/address.go
+++ b/address.go
@@ -1,4 +1,20 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
+/*
+ * Flow Go SDK
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package flow
 

--- a/address.go
+++ b/address.go
@@ -1,57 +1,75 @@
-/*
- * Flow Go SDK
- *
- * Copyright 2019-2020 Dapper Labs, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
 
 package flow
 
 import (
-	"encoding/gob"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strings"
 )
 
-const (
-	// AddressLength is the size of an account address.
-	AddressLength = 8
-)
+// A ChainID is a unique identifier for a specific Flow network instance.
+//
+// Chain IDs are used used to prevent replay attacks and to support network-specific address generation.
+type ChainID string
 
-func init() {
-	gob.Register(Address{})
+// Mainnet is the chain ID for the mainnet node chain.
+const Mainnet ChainID = "flow-mainnet"
+
+// Testnet is the chain ID for the testnet node chain.
+const Testnet ChainID = "flow-testnet"
+
+// Emulator is the chain ID for the emulated node chain.
+const Emulator ChainID = "flow-emulator"
+
+func (id ChainID) String() string {
+	return string(id)
 }
 
-// An Address is a 64-bit identifier for a Flow account.
+// Address represents the 8 byte address of an account.
 type Address [AddressLength]byte
 
-var (
-	// ZeroAddress represents the "zero address" (account that no one owns).
-	ZeroAddress = Address{}
-	// RootAddress is the address of the Flow root account.
-	RootAddress = BytesToAddress(big.NewInt(1).Bytes())
+// AddressState represents the internal state of the address generation mechanism
+type AddressState uint64
+
+const (
+	// AddressLength is the size of an account address in bytes.
+	// (n) is the size of an account address in bits.
+	AddressLength = (linearCodeN + 7) >> 3
+	// AddressStateLength is the size of an account address state in bytes.
+	// (k) is the size of an account address in bits.
+	AddressStateLength = (linearCodeK + 7) >> 3
+
+	// ZeroAddressState is the addressing state when Flow is bootstrapped
+	ZeroAddressState = AddressState(0)
+	// ServiceAddressState is the initial addressing state for account creations
+	ServiceAddressState = AddressState(1)
 )
 
-// BytesToAddress returns Address with value b.
-//
-// If b is larger than len(h), b will be cropped from the left.
-func BytesToAddress(b []byte) Address {
-	var a Address
-	a.SetBytes(b)
-	return a
+// chainCustomizer derives the constant used to generate addresses for 
+// the given chain.
+func chainCustomizer(chain ChainID) uint64 {
+	switch chain {
+	case Mainnet:
+		return 0
+	case Testnet:
+		return invalidCodeTestnet
+	case Emulator:
+		return invalidCodeEmulator
+	default:
+		panic("chain ID is invalid")
+	}
+}
+
+// ZeroAddress represents the "zero address" (account that no one owns).
+func ZeroAddress(chain ChainID) Address {
+	return generateAddress(chain, ZeroAddressState)
+}
+
+// ServiceAddress represents the root (first) generated account address.
+func ServiceAddress(chain ChainID) Address {
+	return generateAddress(chain, ServiceAddressState)
 }
 
 // HexToAddress converts a hex string to an Address.
@@ -60,37 +78,30 @@ func HexToAddress(h string) Address {
 	return BytesToAddress(b)
 }
 
-// SetBytes sets this address to the value of b.
+// BytesToAddress returns Address with value b.
 //
-// If b is larger than len(a) it will panic.
-func (a *Address) SetBytes(b []byte) {
-	if len(b) > len(a) {
+// If b is larger than 8, b will be cropped from the left.
+// If b is smaller than 8, b will be appended by zeroes at the front.
+func BytesToAddress(b []byte) Address {
+	var a Address
+	if len(b) > AddressLength {
 		b = b[len(b)-AddressLength:]
 	}
 	copy(a[AddressLength-len(b):], b)
+	return a
 }
 
-// Bytes returns the byte representation of this address.
+// Bytes returns the byte representation of the address.
 func (a Address) Bytes() []byte { return a[:] }
 
-// Hex returns the hex string representation of this address.
+// Hex returns the hex string representation of the address.
 func (a Address) Hex() string {
 	return hex.EncodeToString(a.Bytes())
 }
 
-// String returns the string representation of this address.
+// String returns the string representation of the address.
 func (a Address) String() string {
 	return a.Hex()
-}
-
-// Short returns the string representation of this address with leading zeros removed.
-func (a Address) Short() string {
-	hex := a.String()
-	trimmed := strings.TrimLeft(hex, "0")
-	if len(trimmed)%2 != 0 {
-		trimmed = "0" + trimmed
-	}
-	return trimmed
 }
 
 func (a Address) MarshalJSON() ([]byte, error) {
@@ -100,4 +111,167 @@ func (a Address) MarshalJSON() ([]byte, error) {
 func (a *Address) UnmarshalJSON(data []byte) error {
 	*a = HexToAddress(strings.Trim(string(data), "\""))
 	return nil
+}
+
+const (
+	// [n,k,d]-Linear code parameters
+	// The linear code used in the account addressing is a [64,45,7]
+	// It generates a [64,45]-code, which is the space of Flow account addresses.
+	//
+	// n is the size of the code words in bits,
+	// which is also the size of the account addresses in bits.
+	linearCodeN = 64
+	// k is size of the words in bits.
+	// 2^k is the total number of possible account addresses.
+	linearCodeK = 45
+	// p is the number of code parity bits.
+	// p = n - k
+	//
+	// d is the distance of the linear code.
+	// It is the minimum hamming distance between any two Flow account addresses.
+	// This means any pair of Flow addresses have at least 7 different bits, which
+	// minimizes the mistakes of typing wrong addresses.
+	// d is also the minimum hamming weight of all account addresses (the zero address is not an account address).
+	linearCodeD = 7
+
+	// the maximum value of the internal state, 2^k.
+	maxState = (1 << linearCodeK) - 1
+)
+
+// AccountAddress generates an account address given an addressing state.
+//
+// The address is generated for a specific network (Flow mainnet, testnet..)
+// The second returned value is the new updated addressing state. The new
+// addressing state should replace the old state to keep generating account
+// addresses in a sequential way.
+// Each state is mapped to exactly one address. There are as many addresses
+// as states.
+// ZeroAddress(chain) corresponds to the state "0" while ServiceAddress() corresponds to the
+// state "1".
+func (state *AddressState) AccountAddress(chain ChainID) (Address, error) {
+	err := state.nextState()
+	if err != nil {
+		return ZeroAddress(chain), err
+	}
+	address := generateAddress(chain, *state)
+	return address, nil
+}
+
+// returns the next state given an addressing state.
+// The state values are incremented from 0 to 2^k-1
+func (state *AddressState) nextState() error {
+	if uint64(*state) > maxState {
+		return fmt.Errorf("the state value is not valid, it must be less or equal to %x", maxState)
+	}
+	*state += 1
+	return nil
+}
+
+// Uint64ToAddress returns an address with value v
+// The value v fits into the address as the address size is 8
+func Uint64ToAddress(v uint64) Address {
+	var b [AddressLength]byte
+	binary.BigEndian.PutUint64(b[:], v)
+	return Address(b)
+}
+
+// uint64 converts an address into a uint64
+func (a *Address) Uint64() uint64 {
+	v := binary.BigEndian.Uint64(a[:])
+	return v
+}
+
+// generateAddress returns an account address given an addressing state.
+// (network) specifies the network to generate the address for (Flow Mainnet, testent..)
+// The function assumes the state is valid (<2^k) which means
+// a check on the state should be done before calling this function.
+func generateAddress(chain ChainID, state AddressState) Address {
+	index := uint64(state)
+
+	// Multiply the index GF(2) vector by the code generator matrix
+	address := uint64(0)
+	for i := 0; i < linearCodeK; i++ {
+		if index&1 == 1 {
+			address ^= generatorMatrixRows[i]
+		}
+		index >>= 1
+	}
+
+	// customize the code word for a specific network
+	address ^= chainCustomizer(chain)
+	return Uint64ToAddress(address)
+}
+
+// IsValid returns true if a given address is a valid account address,
+// and false otherwise.
+//
+// This is an off-chain check that only tells whether the address format is
+// valid. If the function returns true, this does not mean
+// a Flow account with this address has been generated. Such a test would
+// require on on-chain check.
+// ZeroAddress fails the check. Although it has a valid format, no account
+// in Flow is assigned to ZeroAddress.
+func (a *Address) IsValid(chain ChainID) bool {
+	codeWord := a.Uint64()
+	codeWord ^= chainCustomizer(chain)
+
+	if codeWord == 0 {
+		return false
+	}
+
+	// Multiply the code word GF(2)-vector by the parity-check matrix
+	parity := uint(0)
+	for i := 0; i < linearCodeN; i++ {
+		if codeWord&1 == 1 {
+			parity ^= parityCheckMatrixColumns[i]
+		}
+		codeWord >>= 1
+	}
+	return parity == 0
+}
+
+// invalid code-words in the [64,45] code
+// these constants are used to generate non-Flow-Mainnet addresses
+const invalidCodeTestnet = uint64(0x6834ba37b3980209)
+const invalidCodeEmulator = uint64(0x1cb159857af02018)
+
+// Rows of the generator matrix G of the [64,45]-code used for Flow addresses.
+// G is a (k x n) matrix with coefficients in GF(2), each row is converted into
+// a big endian integer representation of the GF(2) raw vector.
+// G is used to generate the account addresses
+var generatorMatrixRows = [linearCodeK]uint64{
+	0xe467b9dd11fa00df, 0xf233dcee88fe0abe, 0xf919ee77447b7497, 0xfc8cf73ba23a260d,
+	0xfe467b9dd11ee2a1, 0xff233dcee888d807, 0xff919ee774476ce6, 0x7fc8cf73ba231d10,
+	0x3fe467b9dd11b183, 0x1ff233dcee8f96d6, 0x8ff919ee774757ba, 0x47fc8cf73ba2b331,
+	0x23fe467b9dd27f6c, 0x11ff233dceee8e82, 0x88ff919ee775dd8f, 0x447fc8cf73b905e4,
+	0xa23fe467b9de0d83, 0xd11ff233dce8d5a7, 0xe88ff919ee73c38a, 0x7447fc8cf73f171f,
+	0xba23fe467b9dcb2b, 0xdd11ff233dcb0cb4, 0xee88ff919ee26c5d, 0x77447fc8cf775dd3,
+	0x3ba23fe467b9b5a1, 0x9dd11ff233d9117a, 0xcee88ff919efa640, 0xe77447fc8cf3e297,
+	0x73ba23fe467fabd2, 0xb9dd11ff233fb16c, 0xdcee88ff919adde7, 0xee77447fc8ceb196,
+	0xf73ba23fe4621cd0, 0x7b9dd11ff2379ac3, 0x3dcee88ff91df46c, 0x9ee77447fc88e702,
+	0xcf73ba23fe4131b6, 0x67b9dd11ff240f9a, 0x33dcee88ff90f9e0, 0x19ee77447fcff4e3,
+	0x8cf73ba23fe64091, 0x467b9dd11ff115c7, 0x233dcee88ffdb735, 0x919ee77447fe2309,
+	0xc8cf73ba23fdc736}
+
+// Columns of the parity-check matrix H of the [64,45]-code used for Flow addresses.
+// H is a (n x p) matrix with coefficients in GF(2), each column is converted into
+// a big endian integer representation of the GF(2) column vector.
+// H is used to verify a code word is a valid account address.
+var parityCheckMatrixColumns = [linearCodeN]uint{
+	0x00001, 0x00002, 0x00004, 0x00008,
+	0x00010, 0x00020, 0x00040, 0x00080,
+	0x00100, 0x00200, 0x00400, 0x00800,
+	0x01000, 0x02000, 0x04000, 0x08000,
+	0x10000, 0x20000, 0x40000, 0x7328d,
+	0x6689a, 0x6112f, 0x6084b, 0x433fd,
+	0x42aab, 0x41951, 0x233ce, 0x22a81,
+	0x21948, 0x1ef60, 0x1deca, 0x1c639,
+	0x1bdd8, 0x1a535, 0x194ac, 0x18c46,
+	0x1632b, 0x1529b, 0x14a43, 0x13184,
+	0x12942, 0x118c1, 0x0f812, 0x0e027,
+	0x0d00e, 0x0c83c, 0x0b01d, 0x0a831,
+	0x0982b, 0x07034, 0x0682a, 0x05819,
+	0x03807, 0x007d2, 0x00727, 0x0068e,
+	0x0067c, 0x0059d, 0x004eb, 0x003b4,
+	0x0036a, 0x002d9, 0x001c7, 0x0003f,
 }

--- a/address.go
+++ b/address.go
@@ -14,14 +14,16 @@ import (
 // Chain IDs are used used to prevent replay attacks and to support network-specific address generation.
 type ChainID string
 
-// Mainnet is the chain ID for the mainnet node chain.
-const Mainnet ChainID = "flow-mainnet"
+const (
+	// Mainnet is the chain ID for the mainnet node chain.
+	Mainnet ChainID = "flow-mainnet"
 
-// Testnet is the chain ID for the testnet node chain.
-const Testnet ChainID = "flow-testnet"
+	// Testnet is the chain ID for the testnet node chain.
+	Testnet ChainID = "flow-testnet"
 
-// Emulator is the chain ID for the emulated node chain.
-const Emulator ChainID = "flow-emulator"
+	// Emulator is the chain ID for the emulated node chain.
+	Emulator ChainID = "flow-emulator"
+)
 
 func (id ChainID) String() string {
 	return string(id)
@@ -138,15 +140,13 @@ const (
 	maxState = (1 << linearCodeK) - 1
 )
 
-// AccountAddress generates an account address given an addressing state.
+// AccountAddress generates an account address and increments 
+// the addressing state.
 //
 // The address is generated for a specific network (Flow mainnet, testnet..)
-// The second returned value is the new updated addressing state. The new
-// addressing state should replace the old state to keep generating account
-// addresses in a sequential way.
 // Each state is mapped to exactly one address. There are as many addresses
 // as states.
-// ZeroAddress(chain) corresponds to the state "0" while ServiceAddress() corresponds to the
+// ZeroAddress() corresponds to the state "0" while ServiceAddress() corresponds to the
 // state "1".
 func (state *AddressState) AccountAddress(chain ChainID) (Address, error) {
 	err := state.nextState()
@@ -157,7 +157,7 @@ func (state *AddressState) AccountAddress(chain ChainID) (Address, error) {
 	return address, nil
 }
 
-// returns the next state given an addressing state.
+// increment the addressing state.
 // The state values are incremented from 0 to 2^k-1
 func (state *AddressState) nextState() error {
 	if uint64(*state) > maxState {

--- a/address_test.go
+++ b/address_test.go
@@ -1,3 +1,21 @@
+/*
+ * Flow Go SDK
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package flow
 
 import (

--- a/address_test.go
+++ b/address_test.go
@@ -43,26 +43,26 @@ func TestFlowAddressConstants(t *testing.T) {
 	for _, net := range networks {
 
 		// check the Zero and Service constants
-		expected := Uint64ToAddress(chainCustomizer(net))
-		assert.Equal(t, ZeroAddress(net), expected)
-		expected = Uint64ToAddress(generatorMatrixRows[0] ^ chainCustomizer(net))
+		expected := uint64ToAddress(chainCustomizer(net))
+		assert.Equal(t, zeroAddress(net), expected)
+		expected = uint64ToAddress(generatorMatrixRows[0] ^ chainCustomizer(net))
 		assert.Equal(t, ServiceAddress(net), expected)
 
 		// check the transition from account zero to service
-		state := ZeroAddressState
-		address, err := state.AccountAddress(net)
+		generator := NewAddressGenerator(net)
+		address, err := generator.NextAddress()
 		require.NoError(t, err)
 		assert.Equal(t, address, ServiceAddress(net))
 
 		// check high state values: generation should fail for high value states
-		state = AddressState(maxState)
-		_, err = state.AccountAddress(net)
+		generator = newAddressGeneratorAtState(net, maxState)
+		_, err = generator.NextAddress()
 		assert.NoError(t, err)
-		_, err = state.AccountAddress(net)
+		_, err = generator.NextAddress()
 		assert.Error(t, err)
 
 		// check ZeroAddress(net) is an invalid addresse
-		z := ZeroAddress(net)
+		z := zeroAddress(net)
 		check := z.IsValid(net)
 		assert.False(t, check, "should be invalid")
 	}
@@ -87,10 +87,10 @@ func TestAddressGeneration(t *testing.T) {
 	for _, net := range networks {
 
 		// sanity check of AccountAddress function consistency
-		state := ZeroAddressState
-		expectedState := ZeroAddressState
+		generator := NewAddressGenerator(net)
+		expectedState := zeroAddressState
 		for i := 0; i < loop; i++ {
-			address, err := state.AccountAddress(net)
+			address, err := generator.NextAddress()
 			require.NoError(t, err)
 			expectedState++
 			expectedAddress := generateAddress(net, expectedState)
@@ -102,11 +102,11 @@ func TestAddressGeneration(t *testing.T) {
 		// this is only a sanity check of the implementation and not an exhaustive proof
 		if net == Mainnet {
 			r := rand.Intn(maxState - loop)
-			state = AddressState(r)
+			generator := newAddressGeneratorAtState(net, addressState(r))
 			for i := 0; i < loop; i++ {
-				address, err := state.AccountAddress(net)
+				address, err := generator.NextAddress()
 				require.NoError(t, err)
-				weight := bits.OnesCount64(address.Uint64())
+				weight := bits.OnesCount64(address.uint64())
 				assert.LessOrEqual(t, linearCodeD, weight)
 			}
 		}
@@ -115,22 +115,22 @@ func TestAddressGeneration(t *testing.T) {
 		// All distances between any two addresses must be less than d.
 		// this is only a sanity check of the implementation and not an exhaustive proof
 		r := rand.Intn(maxState - loop - 1)
-		state = AddressState(r)
-		refAddress, err := state.AccountAddress(net)
+		generator = newAddressGeneratorAtState(net, addressState(r))
+		refAddress, err := generator.NextAddress()
 		require.NoError(t, err)
 		for i := 0; i < loop; i++ {
-			address, err := state.AccountAddress(net)
+			address, err := generator.NextAddress()
 			require.NoError(t, err)
-			distance := bits.OnesCount64(address.Uint64() ^ refAddress.Uint64())
+			distance := bits.OnesCount64(address.uint64() ^ refAddress.uint64())
 			assert.LessOrEqual(t, linearCodeD, distance)
 		}
 
 		// sanity check of valid account addresses.
 		// All valid addresses must pass IsValid.
 		r = rand.Intn(maxState - loop)
-		state = AddressState(r)
+		generator = newAddressGeneratorAtState(net, addressState(r))
 		for i := 0; i < loop; i++ {
-			address, err := state.AccountAddress(net)
+			address, err := generator.NextAddress()
 			require.NoError(t, err)
 			check := address.IsValid(net)
 			assert.True(t, check, "account address format should be valid")
@@ -138,15 +138,15 @@ func TestAddressGeneration(t *testing.T) {
 
 		// sanity check of invalid account addresses.
 		// All invalid addresses must fail IsValid.
-		invalidAddress := Uint64ToAddress(invalidCodeWord)
+		invalidAddress := uint64ToAddress(invalidCodeWord)
 		check := invalidAddress.IsValid(net)
 		assert.False(t, check, "account address format should be invalid")
 		r = rand.Intn(maxState - loop)
-		state = AddressState(r)
+		generator = newAddressGeneratorAtState(net, addressState(r))
 		for i := 0; i < loop; i++ {
-			address, err := state.AccountAddress(net)
+			address, err := generator.NextAddress()
 			require.NoError(t, err)
-			invalidAddress = Uint64ToAddress(address.Uint64() ^ invalidCodeWord)
+			invalidAddress = uint64ToAddress(address.uint64() ^ invalidCodeWord)
 			check := invalidAddress.IsValid(net)
 			assert.False(t, check, "account address format should be invalid")
 		}
@@ -170,9 +170,9 @@ func TestAddressesIntersection(t *testing.T) {
 
 		// All valid test addresses must fail Flow Mainnet check
 		r := rand.Intn(maxState - loop)
-		state := AddressState(r)
+		generator := newAddressGeneratorAtState(net, addressState(r))
 		for i := 0; i < loop; i++ {
-			address, err := state.AccountAddress(net)
+			address, err := generator.NextAddress()
 			require.NoError(t, err)
 			check := address.IsValid(Mainnet)
 			assert.False(t, check, "test account address format should be invalid in Flow")
@@ -180,9 +180,9 @@ func TestAddressesIntersection(t *testing.T) {
 
 		// sanity check: mainnet addresses must fail the test check
 		r = rand.Intn(maxState - loop)
-		state = AddressState(r)
+		generator = newAddressGeneratorAtState(Mainnet, addressState(r))
 		for i := 0; i < loop; i++ {
-			invalidAddress, err := state.AccountAddress(Mainnet)
+			invalidAddress, err := generator.NextAddress()
 			require.NoError(t, err)
 			check := invalidAddress.IsValid(net)
 			assert.False(t, check, "account address format should be invalid")
@@ -190,15 +190,15 @@ func TestAddressesIntersection(t *testing.T) {
 
 		// sanity check of invalid account addresses in all networks
 		require.NotEqual(t, invalidCodeWord, uint64(0))
-		invalidAddress := Uint64ToAddress(invalidCodeWord)
+		invalidAddress := uint64ToAddress(invalidCodeWord)
 		check := invalidAddress.IsValid(net)
 		assert.False(t, check, "account address format should be invalid")
 		r = rand.Intn(maxState - loop)
-		state = AddressState(r)
+		generator = newAddressGeneratorAtState(net, addressState(r))
 		for i := 0; i < loop; i++ {
-			address, err := state.AccountAddress(net)
+			address, err := generator.NextAddress()
 			require.NoError(t, err)
-			invalidAddress = Uint64ToAddress(address.Uint64() ^ invalidCodeWord)
+			invalidAddress = uint64ToAddress(address.uint64() ^ invalidCodeWord)
 			// must fail test network check
 			check = invalidAddress.IsValid(net)
 			assert.False(t, check, "account address format should be invalid")
@@ -208,4 +208,3 @@ func TestAddressesIntersection(t *testing.T) {
 		}
 	}
 }
-

--- a/address_test.go
+++ b/address_test.go
@@ -1,41 +1,26 @@
-/*
- * Flow Go SDK
- *
- * Copyright 2019-2020 Dapper Labs, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package flow_test
+package flow
 
 import (
 	"encoding/json"
+	"math/bits"
+	"math/rand"
 	"testing"
+	"time"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/flow-go-sdk"
 )
 
 type addressWrapper struct {
-	Address flow.Address
+	Address Address
 }
 
-func TestAddress_JSON(t *testing.T) {
-	addr := flow.RootAddress
+func TestAddressJSON(t *testing.T) {
+	addr := ServiceAddress(Mainnet)
 	data, err := json.Marshal(addressWrapper{Address: addr})
 	require.Nil(t, err)
+
+	t.Log(string(data))
 
 	var out addressWrapper
 	err = json.Unmarshal(data, &out)
@@ -43,32 +28,184 @@ func TestAddress_JSON(t *testing.T) {
 	assert.Equal(t, addr, out.Address)
 }
 
-func TestAddress_Short(t *testing.T) {
-	type testcase struct {
-		addr     flow.Address
-		expected string
+func TestFlowAddressConstants(t *testing.T) {
+	// check n and k fit in 8 and 6 bytes
+	assert.LessOrEqual(t, linearCodeN, 8*8)
+	assert.LessOrEqual(t, linearCodeK, 6*8)
+
+	// Test addresses for all type of networks
+	networks := []ChainID{
+		Mainnet,
+		Testnet,
+		Emulator,
 	}
 
-	cases := []testcase{
-		{
-			addr:     flow.RootAddress,
-			expected: "01",
-		},
-		{
-			addr:     flow.HexToAddress("0000000002"),
-			expected: "02",
-		},
-		{
-			addr:     flow.HexToAddress("1f10"),
-			expected: "1f10",
-		},
-		{
-			addr:     flow.HexToAddress("0f10"),
-			expected: "0f10",
-		},
-	}
+	for _, net := range networks {
 
-	for _, c := range cases {
-		assert.Equal(t, c.addr.Short(), c.expected)
+		// check the Zero and Root constants
+		expected := Uint64ToAddress(chainCustomizer(net))
+		assert.Equal(t, ZeroAddress(net), expected)
+		expected = Uint64ToAddress(generatorMatrixRows[0] ^ chainCustomizer(net))
+		assert.Equal(t, ServiceAddress(net), expected)
+
+		// check the transition from account zero to root
+		state := ZeroAddressState
+		address, err := state.AccountAddress(net)
+		require.NoError(t, err)
+		assert.Equal(t, address, ServiceAddress(net))
+
+		// check high state values: generation should fail for high value states
+		state = AddressState(maxState)
+		_, err = state.AccountAddress(net)
+		assert.NoError(t, err)
+		_, err = state.AccountAddress(net)
+		assert.Error(t, err)
+
+		// check ZeroAddress(net) is an invalid addresse
+		z := ZeroAddress(net)
+		check := z.IsValid(net)
+		assert.False(t, check, "should be invalid")
 	}
 }
+
+const invalidCodeWord = uint64(0xab2ae42382900010)
+
+func TestAddressGeneration(t *testing.T) {
+	// seed random generator
+	rand.Seed(time.Now().UnixNano())
+
+	// loops in each test
+	const loop = 3
+
+	// Test addresses for all type of networks
+	networks := []ChainID{
+		Mainnet,
+		Testnet,
+		Emulator,
+	}
+
+	for _, net := range networks {
+
+		// sanity check of AccountAddress function consistency
+		state := ZeroAddressState
+		expectedState := ZeroAddressState
+		for i := 0; i < loop; i++ {
+			address, err := state.AccountAddress(net)
+			require.NoError(t, err)
+			expectedState++
+			expectedAddress := generateAddress(net, expectedState)
+			assert.Equal(t, address, expectedAddress)
+		}
+
+		// sanity check of addresses weights in Flow.
+		// All addresses hamming weights must be less than d.
+		// this is only a sanity check of the implementation and not an exhaustive proof
+		if net == Mainnet {
+			r := rand.Intn(maxState - loop)
+			state = AddressState(r)
+			for i := 0; i < loop; i++ {
+				address, err := state.AccountAddress(net)
+				require.NoError(t, err)
+				weight := bits.OnesCount64(address.Uint64())
+				assert.LessOrEqual(t, linearCodeD, weight)
+			}
+		}
+
+		// sanity check of address distances.
+		// All distances between any two addresses must be less than d.
+		// this is only a sanity check of the implementation and not an exhaustive proof
+		r := rand.Intn(maxState - loop - 1)
+		state = AddressState(r)
+		refAddress, err := state.AccountAddress(net)
+		require.NoError(t, err)
+		for i := 0; i < loop; i++ {
+			address, err := state.AccountAddress(net)
+			require.NoError(t, err)
+			distance := bits.OnesCount64(address.Uint64() ^ refAddress.Uint64())
+			assert.LessOrEqual(t, linearCodeD, distance)
+		}
+
+		// sanity check of valid account addresses.
+		// All valid addresses must pass IsValid.
+		r = rand.Intn(maxState - loop)
+		state = AddressState(r)
+		for i := 0; i < loop; i++ {
+			address, err := state.AccountAddress(net)
+			require.NoError(t, err)
+			check := address.IsValid(net)
+			assert.True(t, check, "account address format should be valid")
+		}
+
+		// sanity check of invalid account addresses.
+		// All invalid addresses must fail IsValid.
+		invalidAddress := Uint64ToAddress(invalidCodeWord)
+		check := invalidAddress.IsValid(net)
+		assert.False(t, check, "account address format should be invalid")
+		r = rand.Intn(maxState - loop)
+		state = AddressState(r)
+		for i := 0; i < loop; i++ {
+			address, err := state.AccountAddress(net)
+			require.NoError(t, err)
+			invalidAddress = Uint64ToAddress(address.Uint64() ^ invalidCodeWord)
+			check := invalidAddress.IsValid(net)
+			assert.False(t, check, "account address format should be invalid")
+		}
+	}
+}
+
+func TestAddressesIntersection(t *testing.T) {
+	// seed random generator
+	rand.Seed(time.Now().UnixNano())
+
+	// loops in each test
+	const loop = 50
+
+	// Test addresses for all type of networks
+	networks := []ChainID{
+		Testnet,
+		Emulator,
+	}
+
+	for _, net := range networks {
+
+		// All valid test addresses must fail Flow Mainnet check
+		r := rand.Intn(maxState - loop)
+		state := AddressState(r)
+		for i := 0; i < loop; i++ {
+			address, err := state.AccountAddress(net)
+			require.NoError(t, err)
+			check := address.IsValid(Mainnet)
+			assert.False(t, check, "test account address format should be invalid in Flow")
+		}
+
+		// sanity check: mainnet addresses must fail the test check
+		r = rand.Intn(maxState - loop)
+		state = AddressState(r)
+		for i := 0; i < loop; i++ {
+			invalidAddress, err := state.AccountAddress(Mainnet)
+			require.NoError(t, err)
+			check := invalidAddress.IsValid(net)
+			assert.False(t, check, "account address format should be invalid")
+		}
+
+		// sanity check of invalid account addresses in all networks
+		require.NotEqual(t, invalidCodeWord, uint64(0))
+		invalidAddress := Uint64ToAddress(invalidCodeWord)
+		check := invalidAddress.IsValid(net)
+		assert.False(t, check, "account address format should be invalid")
+		r = rand.Intn(maxState - loop)
+		state = AddressState(r)
+		for i := 0; i < loop; i++ {
+			address, err := state.AccountAddress(net)
+			require.NoError(t, err)
+			invalidAddress = Uint64ToAddress(address.Uint64() ^ invalidCodeWord)
+			// must fail test network check
+			check = invalidAddress.IsValid(net)
+			assert.False(t, check, "account address format should be invalid")
+			// must fail mainnet check
+			check := invalidAddress.IsValid(Mainnet)
+			assert.False(t, check, "account address format should be invalid")
+		}
+	}
+}
+

--- a/address_test.go
+++ b/address_test.go
@@ -42,13 +42,13 @@ func TestFlowAddressConstants(t *testing.T) {
 
 	for _, net := range networks {
 
-		// check the Zero and Root constants
+		// check the Zero and Service constants
 		expected := Uint64ToAddress(chainCustomizer(net))
 		assert.Equal(t, ZeroAddress(net), expected)
 		expected = Uint64ToAddress(generatorMatrixRows[0] ^ chainCustomizer(net))
 		assert.Equal(t, ServiceAddress(net), expected)
 
-		// check the transition from account zero to root
+		// check the transition from account zero to service
 		state := ZeroAddressState
 		address, err := state.AccountAddress(net)
 		require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -351,7 +351,8 @@ func TestClient_GetTransactionResult(t *testing.T) {
 
 func TestClient_GetAccount(t *testing.T) {
 	accounts := test.AccountGenerator()
-	addresses := test.AddressGenerator()
+	chain := flow.Mainnet
+	var addresses = flow.ZeroAddressState
 
 	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		expectedAccount := accounts.New()
@@ -368,7 +369,7 @@ func TestClient_GetAccount(t *testing.T) {
 	}))
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
-		address := addresses.New()
+		address, err := addresses.AccountAddress(chain)
 
 		rpc.On("GetAccount", ctx, mock.Anything).
 			Return(nil, mockRPCError)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -351,8 +351,7 @@ func TestClient_GetTransactionResult(t *testing.T) {
 
 func TestClient_GetAccount(t *testing.T) {
 	accounts := test.AccountGenerator()
-	chain := flow.Mainnet
-	var addresses = flow.ZeroAddressState
+	addresses := flow.NewAddressGenerator(flow.Mainnet)
 
 	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
 		expectedAccount := accounts.New()
@@ -369,7 +368,8 @@ func TestClient_GetAccount(t *testing.T) {
 	}))
 
 	t.Run("Error", clientTest(func(t *testing.T, ctx context.Context, rpc *mocks.RPCClient, c *client.Client) {
-		address, err := addresses.AccountAddress(chain)
+		address, err := addresses.NextAddress()
+		require.NoError(t, err)
 
 		rpc.On("GetAccount", ctx, mock.Anything).
 			Return(nil, mockRPCError)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -44,18 +44,6 @@ func (f SignatureAlgorithm) String() string {
 	return [...]string{"UNKNOWN", "BLS_BLS12381", "ECDSA_P256", "ECDSA_secp256k1"}[f]
 }
 
-// MinSeedLength returns the minimum seed length that can safely be used to generate private keys with this algorithm.
-func (f SignatureAlgorithm) MinSeedLength() int {
-	switch f {
-	case ECDSA_P256:
-		return crypto.KeyGenSeedMinLenECDSAP256
-	case ECDSA_secp256k1:
-		return crypto.KeyGenSeedMinLenECDSASecp256k1
-	}
-
-	return 0
-}
-
 // StringToSignatureAlgorithm converts a string to a SignatureAlgorithm.
 func StringToSignatureAlgorithm(s string) SignatureAlgorithm {
 	switch s {
@@ -235,11 +223,12 @@ func keyGenerationKMACTag(sigAlgo SignatureAlgorithm) []byte {
 
 // GeneratePrivateKey generates a private key with the specified signature algorithm from the given seed.
 func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, error) {
-	if len(seed) < sigAlgo.MinSeedLength() {
+	// check the seed has minimum entropy
+	if len(seed) < MinSeedLength {
 		return PrivateKey{}, fmt.Errorf(
 			"crypto: insufficient seed length %d, must be at least %d bytes for %s",
 			len(seed),
-			sigAlgo.MinSeedLength(),
+			MinSeedLength,
 			sigAlgo,
 		)
 	}
@@ -267,6 +256,7 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 
 	hashedSeed := hasher.ComputeHash(seed)
 
+	// generate the key
 	privKey, err := crypto.GeneratePrivateKey(crypto.SigningAlgorithm(sigAlgo), hashedSeed)
 	if err != nil {
 		return PrivateKey{}, err

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -256,7 +256,6 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 
 	hashedSeed := hasher.ComputeHash(seed)
 
-	// generate the key
 	privKey, err := crypto.GeneratePrivateKey(crypto.SigningAlgorithm(sigAlgo), hashedSeed)
 	if err != nil {
 		return PrivateKey{}, err

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -248,6 +248,7 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 	}
 
 	generationTag := keyGenerationKMACTag(sigAlgo)
+
 	customizer := []byte("")
 	hasher, err := hash.NewKMAC_128(generationTag, customizer, seedLen)
 	if err != nil {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -44,6 +44,18 @@ func (f SignatureAlgorithm) String() string {
 	return [...]string{"UNKNOWN", "BLS_BLS12381", "ECDSA_P256", "ECDSA_secp256k1"}[f]
 }
 
+// MinSeedLength returns the minimum seed length that can safely be used to generate private keys with this algorithm.
+func (f SignatureAlgorithm) MinSeedLength() int {
+	switch f {
+	case ECDSA_P256:
+		return crypto.KeyGenSeedMinLenECDSAP256
+	case ECDSA_secp256k1:
+		return crypto.KeyGenSeedMinLenECDSASecp256k1
+	}
+
+	return 0
+}
+
 // StringToSignatureAlgorithm converts a string to a SignatureAlgorithm.
 func StringToSignatureAlgorithm(s string) SignatureAlgorithm {
 	switch s {
@@ -223,12 +235,11 @@ func keyGenerationKMACTag(sigAlgo SignatureAlgorithm) []byte {
 
 // GeneratePrivateKey generates a private key with the specified signature algorithm from the given seed.
 func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, error) {
-	// check the seed has minimum entropy
-	if len(seed) < MinSeedLength {
+	if len(seed) < sigAlgo.MinSeedLength() {
 		return PrivateKey{}, fmt.Errorf(
 			"crypto: insufficient seed length %d, must be at least %d bytes for %s",
 			len(seed),
-			MinSeedLength,
+			sigAlgo.MinSeedLength(),
 			sigAlgo,
 		)
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -248,7 +248,6 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 	}
 
 	generationTag := keyGenerationKMACTag(sigAlgo)
-
 	customizer := []byte("")
 	hasher, err := hash.NewKMAC_128(generationTag, customizer, seedLen)
 	if err != nil {

--- a/examples/create_account/main.go
+++ b/examples/create_account/main.go
@@ -40,7 +40,7 @@ func CreateAccountDemo() {
 	flowClient, err := client.New("127.0.0.1:3569", grpc.WithInsecure())
 	examples.Handle(err)
 
-	rootAcctAddr, rootAcctKey, rootSigner := examples.RootAccount(flowClient)
+	serviceAcctAddr, serviceAcctKey, serviceSigner := examples.ServiceAccount(flowClient)
 
 	myPrivateKey := examples.RandomPrivateKey()
 	myAcctKey := flow.NewAccountKey().
@@ -53,15 +53,15 @@ func CreateAccountDemo() {
 	examples.Handle(err)
 
 	// Create a transaction that will execute the script. The transaction is signed
-	// by the root account.
+	// by the service account.
 	createAccountTx := flow.NewTransaction().
 		SetScript(createAccountScript).
-		SetProposalKey(rootAcctAddr, rootAcctKey.ID, rootAcctKey.SequenceNumber).
-		SetPayer(rootAcctAddr)
+		SetProposalKey(serviceAcctAddr, serviceAcctKey.ID, serviceAcctKey.SequenceNumber).
+		SetPayer(serviceAcctAddr)
 
-	// Sign the transaction with the root account, which already exists
+	// Sign the transaction with the service account, which already exists
 	// All new accounts must be created by an existing account
-	err = createAccountTx.SignEnvelope(rootAcctAddr, rootAcctKey.ID, rootSigner)
+	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.ID, serviceSigner)
 	examples.Handle(err)
 
 	// Send the transaction to the network

--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -45,7 +45,7 @@ func DeployContractDemo() {
 	flowClient, err := client.New("127.0.0.1:3569", grpc.WithInsecure())
 	examples.Handle(err)
 
-	rootAcctAddr, rootAcctKey, rootSigner := examples.RootAccount(flowClient)
+	serviceAcctAddr, serviceAcctKey, serviceSigner := examples.ServiceAccount(flowClient)
 
 	myPrivateKey := examples.RandomPrivateKey()
 	myAcctKey := flow.NewAccountKey().
@@ -60,10 +60,10 @@ func DeployContractDemo() {
 
 	createAccountTx := flow.NewTransaction().
 		SetScript(createAccountScript).
-		SetProposalKey(rootAcctAddr, rootAcctKey.ID, rootAcctKey.SequenceNumber).
-		SetPayer(rootAcctAddr)
+		SetProposalKey(serviceAcctAddr, serviceAcctKey.ID, serviceAcctKey.SequenceNumber).
+		SetPayer(serviceAcctAddr)
 
-	err = createAccountTx.SignEnvelope(rootAcctAddr, rootAcctKey.ID, rootSigner)
+	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.ID, serviceSigner)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *createAccountTx)
@@ -73,7 +73,7 @@ func DeployContractDemo() {
 	examples.Handle(accountCreationTxRes.Error)
 
 	// Successful Tx, increment sequence number
-	rootAcctKey.SequenceNumber++
+	serviceAcctKey.SequenceNumber++
 
 	var myAddress flow.Address
 

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -61,6 +61,7 @@ func RootAccount(flowClient *client.Client) (flow.Address, *flow.AccountKey, cry
 // RandomPrivateKey returns a randomly generated ECDSA P-256 private key.
 func RandomPrivateKey() crypto.PrivateKey {
 	seed := make([]byte, crypto.MinSeedLength)
+
 	_, err := rand.Read(seed)
 	if err != nil {
 		panic(err)

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -61,7 +61,10 @@ func RootAccount(flowClient *client.Client) (flow.Address, *flow.AccountKey, cry
 // RandomPrivateKey returns a randomly generated ECDSA P-256 private key.
 func RandomPrivateKey() crypto.PrivateKey {
 	seed := make([]byte, crypto.MinSeedLength)
-	rand.Read(seed)
+	_, err := rand.Read(seed)
+	if err != nil {
+		panic(err)
+	}
 
 	privateKey, err := crypto.GeneratePrivateKey(crypto.ECDSA_P256, seed)
 	if err != nil {

--- a/examples/flow.json
+++ b/examples/flow.json
@@ -1,7 +1,7 @@
 {
 	"accounts": {
-		"root": {
-			"address": "0000000000000000000000000000000000000001",
+		"service": {
+			"address": "e467b9dd11fa00df",
 			"privateKey": "bf9db4706c2fdb9011ee7e170ccac492f05427b96ab41d8bf2d8c58443704b76",
 			"sigAlgorithm": "ECDSA_P256",
 			"hashAlgorithm": "SHA3_256"

--- a/flow.go
+++ b/flow.go
@@ -58,6 +58,24 @@ func HashToID(hash []byte) Identifier {
 	return BytesToID(hash)
 }
 
+// A ChainID is a unique identifier for a specific Flow network instance.
+//
+// Chain IDs are used used to prevent replay attacks and to support network-specific address generation.
+type ChainID string
+
+// Mainnet is the chain ID for the mainnet node chain.
+const Mainnet ChainID = "flow-mainnet"
+
+// Testnet is the chain ID for the testnet node chain.
+const Testnet ChainID = "flow-testnet"
+
+// Emulator is the chain ID for the emulated node chain.
+const Emulator ChainID = "flow-emulator"
+
+func (id ChainID) String() string {
+	return string(id)
+}
+
 // DefaultHasher is the default hasher used by Flow.
 var DefaultHasher crypto.Hasher
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ethereum/go-ethereum v1.9.9
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/lithammer/dedent v1.1.0
-	github.com/magiconair/properties v1.8.1
 	github.com/onflow/cadence v0.3.0-beta1
 	github.com/onflow/flow/protobuf/go/flow v0.1.4
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,10 @@ github.com/onflow/cadence v0.3.0-beta1 h1:hvCoaDfGRCWbS+M6S+5uyh9CRjd7uGJvOtuPB4
 github.com/onflow/cadence v0.3.0-beta1/go.mod h1:GaLQ7IsJi5bqpH66GprNs8uoQtperK/xbXXIOq11nZw=
 github.com/onflow/flow/protobuf/go/flow v0.1.4 h1:xRdLYCxR/V6lq03ElK3g0T/F8pCIpLrKs2IHQTYr9rM=
 github.com/onflow/flow/protobuf/go/flow v0.1.4/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/cadence v0.2.0 h1:Y4f7npDXcVraAF6a81KAcNMCe/5+lK7ZeEyYpGaNyZs=
+github.com/onflow/cadence v0.2.0/go.mod h1:GaLQ7IsJi5bqpH66GprNs8uoQtperK/xbXXIOq11nZw=
+github.com/onflow/flow/protobuf/go/flow v0.1.3 h1:xT/wjpc0CyGo6Jldn3H+5Y2G42tp+TE2Jg2BNA9x/mk=
+github.com/onflow/flow/protobuf/go/flow v0.1.3/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
-github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -142,10 +140,6 @@ github.com/onflow/cadence v0.3.0-beta1 h1:hvCoaDfGRCWbS+M6S+5uyh9CRjd7uGJvOtuPB4
 github.com/onflow/cadence v0.3.0-beta1/go.mod h1:GaLQ7IsJi5bqpH66GprNs8uoQtperK/xbXXIOq11nZw=
 github.com/onflow/flow/protobuf/go/flow v0.1.4 h1:xRdLYCxR/V6lq03ElK3g0T/F8pCIpLrKs2IHQTYr9rM=
 github.com/onflow/flow/protobuf/go/flow v0.1.4/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
-github.com/onflow/cadence v0.2.0 h1:Y4f7npDXcVraAF6a81KAcNMCe/5+lK7ZeEyYpGaNyZs=
-github.com/onflow/cadence v0.2.0/go.mod h1:GaLQ7IsJi5bqpH66GprNs8uoQtperK/xbXXIOq11nZw=
-github.com/onflow/flow/protobuf/go/flow v0.1.3 h1:xT/wjpc0CyGo6Jldn3H+5Y2G42tp+TE2Jg2BNA9x/mk=
-github.com/onflow/flow/protobuf/go/flow v0.1.3/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/test/entities.go
+++ b/test/entities.go
@@ -310,7 +310,6 @@ func (g *Transactions) NewUnsigned() *flow.Transaction {
 	accountB := accounts.New()
 
 	return flow.NewTransaction().
-		SetChainID(accounts.chain).
 		SetScript(ScriptHelloWorld).
 		SetReferenceBlockID(blockID).
 		SetGasLimit(42).

--- a/test/entities.go
+++ b/test/entities.go
@@ -31,15 +31,13 @@ import (
 var ScriptHelloWorld = []byte(`transaction { execute { log("Hello, World!") } }`)
 
 type Accounts struct {
-	chain       flow.ChainID
-	addresses   flow.AddressState
+	addresses   *flow.AddressGenerator
 	accountKeys *AccountKeys
 }
 
 func AccountGenerator() *Accounts {
 	return &Accounts{
-		chain:		 flow.Mainnet,
-		addresses:   flow.ZeroAddressState,
+		addresses:   flow.NewAddressGenerator(flow.Mainnet),
 		accountKeys: AccountKeyGenerator(),
 	}
 }
@@ -47,10 +45,12 @@ func AccountGenerator() *Accounts {
 func (g *Accounts) New() *flow.Account {
 	var address flow.Address
 	var err error
-	address , err = g.addresses.AccountAddress(g.chain)
+
+	address, err = g.addresses.NextAddress()
 	if err != nil {
 		return &flow.Account{}
 	}
+
 	return &flow.Account{
 		Address: address,
 		Balance: 10,

--- a/transaction.go
+++ b/transaction.go
@@ -28,7 +28,6 @@ import (
 type Transaction struct {
 	Script             []byte
 	ReferenceBlockID   Identifier
-	chain			   ChainID	
 	GasLimit           uint64
 	ProposalKey        ProposalKey
 	Payer              Address
@@ -45,12 +44,6 @@ func NewTransaction() *Transaction {
 // ID returns the canonical SHA3-256 hash of this transaction.
 func (t *Transaction) ID() Identifier {
 	return HashToID(DefaultHasher.ComputeHash(t.Encode()))
-}
-
-// SetChainID sets the specific Flow instance 
-func (t *Transaction) SetChainID(chain ChainID) *Transaction {
-	t.chain = chain
-	return t
 }
 
 // SetScript sets the Cadence script for this transaction.
@@ -120,11 +113,13 @@ func (t *Transaction) signerList() []Address {
 		seen[address] = struct{}{}
 	}
 
-	if t.ProposalKey.Address != ZeroAddress(t.chain) {
+	emptyAddress := Address{}
+	
+	if t.ProposalKey.Address != emptyAddress {
 		addSigner(t.ProposalKey.Address)
 	}
 
-	if t.Payer != ZeroAddress(t.chain) {
+	if t.Payer != emptyAddress {
 		addSigner(t.Payer)
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -28,6 +28,7 @@ import (
 type Transaction struct {
 	Script             []byte
 	ReferenceBlockID   Identifier
+	chain			   ChainID	
 	GasLimit           uint64
 	ProposalKey        ProposalKey
 	Payer              Address
@@ -44,6 +45,12 @@ func NewTransaction() *Transaction {
 // ID returns the canonical SHA3-256 hash of this transaction.
 func (t *Transaction) ID() Identifier {
 	return HashToID(DefaultHasher.ComputeHash(t.Encode()))
+}
+
+// SetChainID sets the specific Flow instance 
+func (t *Transaction) SetChainID(chain ChainID) *Transaction {
+	t.chain = chain
+	return t
 }
 
 // SetScript sets the Cadence script for this transaction.
@@ -113,11 +120,11 @@ func (t *Transaction) signerList() []Address {
 		seen[address] = struct{}{}
 	}
 
-	if t.ProposalKey.Address != ZeroAddress {
+	if t.ProposalKey.Address != ZeroAddress(t.chain) {
 		addSigner(t.ProposalKey.Address)
 	}
 
-	if t.Payer != ZeroAddress {
+	if t.Payer != ZeroAddress(t.chain) {
 		addSigner(t.Payer)
 	}
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -52,7 +52,6 @@ func ExampleTransaction() {
 
 	blaineHardwareKey := &flow.AccountKey{ID: 7}
 	addressB, _ := addresses.AccountAddress(chain)
-	
 
 	blaine := flow.Account{
 		Address: addressB,
@@ -64,7 +63,6 @@ func ExampleTransaction() {
 	// Transaction preparation
 
 	tx := flow.NewTransaction().
-		SetChainID(chain).
 		SetScript([]byte(`transaction { execute { log("Hello, World!") } }`)).
 		SetReferenceBlockID(flow.Identifier{0x01, 0x02}).
 		SetGasLimit(42).
@@ -115,6 +113,7 @@ func ExampleTransaction() {
 
 	fmt.Printf("Transaction ID (after signing): %s\n", tx.ID())
 
+	// Output:
 	// Transaction ID (before signing): f40d6faded57cd64fb1cb544774464c60c22c08f5d174011e6188e9c8ac64ec8
 	//
 	// Payload signatures:
@@ -202,8 +201,7 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 	var addresses = flow.ZeroAddressState
 
 	t.Run("Invalid signer", func(t *testing.T) {
-		tx := flow.NewTransaction().
-			SetChainID(chain)
+		tx := flow.NewTransaction()
 
 		address, err := addresses.AccountAddress(chain)
 		require.NoError(t, err)
@@ -226,7 +224,6 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		sig := []byte{42}
 
 		tx := flow.NewTransaction().
-			SetChainID(chain).
 			AddAuthorizer(addressA).
 			AddAuthorizer(addressB)
 
@@ -257,7 +254,6 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		sig := []byte{42}
 
 		tx := flow.NewTransaction().
-			SetChainID(chain).
 			SetProposalKey(addressA, keyID, 42).
 			AddAuthorizer(addressB).
 			AddAuthorizer(addressA)
@@ -290,7 +286,6 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		sigB := []byte{43}
 
 		tx := flow.NewTransaction().
-			SetChainID(chain).
 			AddAuthorizer(address)
 
 		// add signatures in descending order by key ID
@@ -317,8 +312,7 @@ func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 	addresses := flow.ZeroAddressState
 
 	t.Run("Invalid signer", func(t *testing.T) {
-		tx := flow.NewTransaction().
-			SetChainID(chain)
+		tx := flow.NewTransaction()
 
 		address, err := addresses.AccountAddress(chain)
 		require.NoError(t, err)
@@ -339,7 +333,6 @@ func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 		sig := []byte{42}
 
 		tx := flow.NewTransaction().
-			SetChainID(chain).
 			SetPayer(address)
 
 		tx.AddEnvelopeSignature(address, keyID, sig)
@@ -362,9 +355,7 @@ func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 		keyIDB := 8
 		sigB := []byte{43}
 
-		tx := flow.NewTransaction().
-			SetChainID(chain).
-			AddAuthorizer(address)
+		tx := flow.NewTransaction().AddAuthorizer(address)
 
 		// add signatures in descending order by key ID
 		tx.AddEnvelopeSignature(address, keyIDB, sigB)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -31,7 +31,8 @@ import (
 
 func ExampleTransaction() {
 	chain := flow.Mainnet
-	addresses := flow.ZeroAddressState
+	addresses := flow.NewAddressGenerator(chain)
+
 	// Mock user accounts
 
 	adrianLaptopKey := &flow.AccountKey{
@@ -40,7 +41,7 @@ func ExampleTransaction() {
 	}
 
 	adrianPhoneKey := &flow.AccountKey{ID: 2}
-	addressA, _ := addresses.AccountAddress(chain)
+	addressA, _ := addresses.NextAddress()
 
 	adrian := flow.Account{
 		Address: addressA,
@@ -51,7 +52,7 @@ func ExampleTransaction() {
 	}
 
 	blaineHardwareKey := &flow.AccountKey{ID: 7}
-	addressB, _ := addresses.AccountAddress(chain)
+	addressB, _ := addresses.NextAddress()
 
 	blaine := flow.Account{
 		Address: addressB,
@@ -175,11 +176,11 @@ func TestTransaction_SetPayer(t *testing.T) {
 
 func TestTransaction_AddAuthorizer(t *testing.T) {
 	chain := flow.Mainnet
-	addresses := flow.ZeroAddressState
+	addresses := flow.NewAddressGenerator(chain)
 
-	addressA, err := addresses.AccountAddress(chain)
+	addressA, err := addresses.NextAddress()
 	require.NoError(t, err)
-	addressB, err := addresses.AccountAddress(chain)
+	addressB, err := addresses.NextAddress()
 	require.NoError(t, err)
 
 	tx := flow.NewTransaction().
@@ -198,12 +199,12 @@ func TestTransaction_AddAuthorizer(t *testing.T) {
 
 func TestTransaction_AddPayloadSignature(t *testing.T) {
 	chain := flow.Mainnet
-	var addresses = flow.ZeroAddressState
+	var addresses = flow.NewAddressGenerator(chain)
 
 	t.Run("Invalid signer", func(t *testing.T) {
 		tx := flow.NewTransaction()
 
-		address, err := addresses.AccountAddress(chain)
+		address, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		tx.AddPayloadSignature(address, 7, []byte{42})
@@ -215,9 +216,9 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 	})
 
 	t.Run("Valid signers", func(t *testing.T) {
-		addressA, err := addresses.AccountAddress(chain)
+		addressA, err := addresses.NextAddress()
 		require.NoError(t, err)
-		addressB, err := addresses.AccountAddress(chain)
+		addressB, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		keyID := 7
@@ -245,9 +246,9 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 	})
 
 	t.Run("Duplicate signers", func(t *testing.T) {
-		addressA, err := addresses.AccountAddress(chain)
+		addressA, err := addresses.NextAddress()
 		require.NoError(t, err)
-		addressB, err := addresses.AccountAddress(chain)
+		addressB, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		keyID := 7
@@ -276,7 +277,7 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 	})
 
 	t.Run("Multiple signatures", func(t *testing.T) {
-		address, err := addresses.AccountAddress(chain)
+		address, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		keyIDA := 7
@@ -309,12 +310,12 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 
 func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 	chain := flow.Mainnet
-	addresses := flow.ZeroAddressState
+	addresses := flow.NewAddressGenerator(chain)
 
 	t.Run("Invalid signer", func(t *testing.T) {
 		tx := flow.NewTransaction()
 
-		address, err := addresses.AccountAddress(chain)
+		address, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		tx.AddEnvelopeSignature(address, 7, []byte{42})
@@ -326,7 +327,7 @@ func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 	})
 
 	t.Run("Valid signer", func(t *testing.T) {
-		address, err := addresses.AccountAddress(chain)
+		address, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		keyID := 7
@@ -346,7 +347,7 @@ func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 	})
 
 	t.Run("Multiple signatures", func(t *testing.T) {
-		address, err := addresses.AccountAddress(chain)
+		address, err := addresses.NextAddress()
 		require.NoError(t, err)
 
 		keyIDA := 7

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -115,7 +115,7 @@ func ExampleTransaction() {
 	fmt.Printf("Transaction ID (after signing): %s\n", tx.ID())
 
 	// Output:
-	// Transaction ID (before signing): f40d6faded57cd64fb1cb544774464c60c22c08f5d174011e6188e9c8ac64ec8
+	// Transaction ID (before signing): 6ba28e395014536e28a4b0a7c122dda7544ffee33015850ed48e8ecf975b46d7
 	//
 	// Payload signatures:
 	// Address: e467b9dd11fa00df, Key ID: 2, Signature: 02
@@ -124,7 +124,7 @@ func ExampleTransaction() {
 	// Envelope signatures:
 	// Address: f233dcee88fe0abe, Key ID: 7, Signature: 03
 	//
-	// Transaction ID (after signing): 9b49d704eaafa58fa5834dbf5272c620d068f177940352072f11158ec1fbfdd1
+	// Transaction ID (after signing): 6f2220ea52cafc2e637d56f1a7b22d697ad5ad4723cc8b04bb183d607b949c20
 }
 
 func TestTransaction_SetScript(t *testing.T) {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func ExampleTransaction() {
-	chain := flow.Mainnet
-	addresses := flow.NewAddressGenerator(chain)
+	addresses := flow.NewAddressGenerator(flow.Mainnet)
 
 	// Mock user accounts
 
@@ -175,8 +174,7 @@ func TestTransaction_SetPayer(t *testing.T) {
 }
 
 func TestTransaction_AddAuthorizer(t *testing.T) {
-	chain := flow.Mainnet
-	addresses := flow.NewAddressGenerator(chain)
+	addresses := flow.NewAddressGenerator(flow.Mainnet)
 
 	addressA, err := addresses.NextAddress()
 	require.NoError(t, err)
@@ -198,8 +196,7 @@ func TestTransaction_AddAuthorizer(t *testing.T) {
 }
 
 func TestTransaction_AddPayloadSignature(t *testing.T) {
-	chain := flow.Mainnet
-	var addresses = flow.NewAddressGenerator(chain)
+	addresses := flow.NewAddressGenerator(flow.Mainnet)
 
 	t.Run("Invalid signer", func(t *testing.T) {
 		tx := flow.NewTransaction()
@@ -309,8 +306,7 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 }
 
 func TestTransaction_AddEnvelopeSignature(t *testing.T) {
-	chain := flow.Mainnet
-	addresses := flow.NewAddressGenerator(chain)
+	addresses := flow.NewAddressGenerator(flow.Mainnet)
 
 	t.Run("Invalid signer", func(t *testing.T) {
 		tx := flow.NewTransaction()


### PR DESCRIPTION
## Description

This PR integrates the new account addressing mechanism. 
 - integrate three addressing mechanisms (mainnet, testnet and emulator).
 - rename `Root` account to `Service` account.
 - new values for `ZeroAddress` and `ServiceAddress`.
 - provide an off-chain method to check addresses validity.