### PR TITLE
client/convert: Skip decoding of block timestamp if nil

### DIFF
--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -21,6 +21,7 @@ package convert
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/onflow/cadence"
@@ -121,16 +122,21 @@ func BlockToMessage(b flow.Block) (*entities.Block, error) {
 }
 
 func MessageToBlock(m *entities.Block) (flow.Block, error) {
-	t, err := ptypes.Timestamp(m.Timestamp)
-	if err != nil {
-		return flow.Block{}, err
+	var timestamp time.Time
+	var err error
+
+	if m.GetTimestamp() != nil {
+		timestamp, err = ptypes.Timestamp(m.GetTimestamp())
+		if err != nil {
+			return flow.Block{}, err
+		}
 	}
 
 	header := &flow.BlockHeader{
 		ID:        flow.HashToID(m.GetId()),
 		ParentID:  flow.HashToID(m.GetParentId()),
 		Height:    m.GetHeight(),
-		Timestamp: t,
+		Timestamp: timestamp,
 	}
 
 	guarantees, err := MessagesToCollectionGuarantees(m.GetCollectionGuarantees())
@@ -167,16 +173,21 @@ func MessageToBlockHeader(m *entities.BlockHeader) (flow.BlockHeader, error) {
 		return flow.BlockHeader{}, ErrEmptyMessage
 	}
 
-	t, err := ptypes.Timestamp(m.Timestamp)
-	if err != nil {
-		return flow.BlockHeader{}, err
+	var timestamp time.Time
+	var err error
+
+	if m.GetTimestamp() != nil {
+		timestamp, err = ptypes.Timestamp(m.GetTimestamp())
+		if err != nil {
+			return flow.BlockHeader{}, err
+		}
 	}
 
 	return flow.BlockHeader{
 		ID:        flow.HashToID(m.GetId()),
 		ParentID:  flow.HashToID(m.GetParentId()),
 		Height:    m.GetHeight(),
-		Timestamp: t,
+		Timestamp: timestamp,
 	}, nil
 }
 

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -20,6 +20,7 @@ package convert_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/onflow/cadence"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,20 @@ func TestConvert_Block(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, *blockA, blockB)
+
+	t.Run("Without timestamp", func(t *testing.T) {
+		blockA := test.BlockGenerator().New()
+
+		msg, err := convert.BlockToMessage(*blockA)
+		require.NoError(t, err)
+
+		msg.Timestamp = nil
+
+		blockB, err = convert.MessageToBlock(msg)
+		require.NoError(t, err)
+
+		assert.Equal(t, time.Time{}, blockB.Timestamp)
+	})
 }
 
 func TestConvert_BlockHeader(t *testing.T) {
@@ -74,6 +89,20 @@ func TestConvert_BlockHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, headerA, headerB)
+
+	t.Run("Without timestamp", func(t *testing.T) {
+		headerA := test.BlockHeaderGenerator().New()
+
+		msg, err := convert.BlockHeaderToMessage(headerA)
+		require.NoError(t, err)
+
+		msg.Timestamp = nil
+
+		headerB, err = convert.MessageToBlockHeader(msg)
+		require.NoError(t, err)
+
+		assert.Equal(t, time.Time{}, headerB.Timestamp)
+	})
 }
 
 func TestConvert_CadenceValue(t *testing.T) {

--- a/test/entities.go
+++ b/test/entities.go
@@ -142,26 +142,29 @@ func (g *Blocks) New() *flow.Block {
 }
 
 type BlockHeaders struct {
-	count    int
-	ids      *Identifiers
-	lastTime time.Time
+	count     int
+	ids       *Identifiers
+	startTime time.Time
 }
 
 func BlockHeaderGenerator() *BlockHeaders {
+	startTime, _ := time.Parse(time.RFC3339, "2020-06-04T15:43:21+00:00")
+
 	return &BlockHeaders{
-		count:    1,
-		ids:      IdentifierGenerator(),
-		lastTime: time.Now().UTC(),
+		count:     1,
+		ids:       IdentifierGenerator(),
+		startTime: startTime.UTC(),
 	}
 }
 
 func (g *BlockHeaders) New() flow.BlockHeader {
 	defer func() { g.count++ }()
+
 	return flow.BlockHeader{
 		ID:        g.ids.New(),
 		ParentID:  g.ids.New(),
 		Height:    uint64(g.count),
-		Timestamp: g.lastTime.Add(1 * time.Second),
+		Timestamp: g.startTime.Add(time.Hour * time.Duration(g.count)),
 	}
 }
 


### PR DESCRIPTION
Closes #46

## Description

This updates the `Block` and `BlockHeader` client methods to be compatible with versions of the Access API that do no implement the `BlockHeader.Timestamp` field.
