### PR TITLE
Update emulator examples to read service key from flow.json

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -62,7 +62,15 @@ type config struct {
 
 func readConfig() config {
 	f, err := os.Open(configPath)
-	Handle(err)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("Emulator examples must be run from the flow-go-sdk/examples directory. Please see flow-go-sdk/examples/README.md for more details.")
+		} else {
+			fmt.Printf("Failed to load config from %s: %s\n", configPath, err.Error())
+		}
+
+		os.Exit(1)
+	}
 
 	d := json.NewDecoder(f)
 

--- a/examples/flow.json
+++ b/examples/flow.json
@@ -2,7 +2,7 @@
 	"accounts": {
 		"service": {
 			"address": "e467b9dd11fa00df",
-			"privateKey": "bf9db4706c2fdb9011ee7e170ccac492f05427b96ab41d8bf2d8c58443704b76",
+			"privateKey": "68ee617d9bf67a4677af80aaca5a090fcda80ff2f4dbc340e0e36201fa1f1d8c",
 			"sigAlgorithm": "ECDSA_P256",
 			"hashAlgorithm": "SHA3_256"
 		}


### PR DESCRIPTION
This PR introduces a small improvement to the `examples` package that loads the service account information from `flow.json` rather than a hard-coded seed.