### PR TITLE
Update crypto comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ tx := flow.NewTransaction().
 Transaction signing is done through the `crypto.Signer` interface. The simplest 
 (and least secure) implementation of `crypto.Signer` is `crypto.InMemorySigner`.
 
-Signatures can be generated more securely using hardware keys stored in a device such 
+Signatures can be generated more securely using keys stored in a hardware device such 
 as an [HSM](https://en.wikipedia.org/wiki/Hardware_security_module). The `crypto.Signer` 
 interface is intended to be flexible enough to support a variety of signer implementations 
 and is not limited to in-memory implementations.

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -175,13 +175,16 @@ func (pk PublicKey) Encode() []byte {
 	return pk.publicKey.Encode()
 }
 
-// A Signer is capable of signing cryptographic messages.
+// A Signer is capable of generating cryptographic signatures.
 type Signer interface {
 	// Sign signs the given message with this signer.
 	Sign(message []byte) ([]byte, error)
 }
 
 // An InMemorySigner is a signer that generates signatures using an in-memory private key.
+//
+// InMemorySigner implements simple signing that does not protect the private key against
+// any tampering or side channel attacks.
 type InMemorySigner struct {
 	PrivateKey PrivateKey
 	Hasher     Hasher


### PR DESCRIPTION

## Description
 - clarify why `InMemorySigner` is considered not secure (it is not simply because the key is in memory).
 - minor comment update 


