### PR TITLE
Add thread-safe entityHasher

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -25,7 +25,7 @@ type Collection struct {
 
 // ID returns the canonical SHA3-256 hash of this collection.
 func (c Collection) ID() Identifier {
-	return HashToID(DefaultHasher.ComputeHash(c.Encode()))
+	return HashToID(defaultEntityHasher.ComputeHash(c.Encode()))
 }
 
 // Encode returns the canonical RLP byte representation of this collection.

--- a/event.go
+++ b/event.go
@@ -50,7 +50,7 @@ func (e Event) String() string {
 
 // ID returns the canonical SHA3-256 hash of this event.
 func (e Event) ID() string {
-	return DefaultHasher.ComputeHash(e.Encode()).Hex()
+	return defaultEntityHasher.ComputeHash(e.Encode()).Hex()
 }
 
 // Encode returns the canonical RLP byte representation of this event.

--- a/transaction.go
+++ b/transaction.go
@@ -48,7 +48,7 @@ func NewTransaction() *Transaction {
 
 // ID returns the canonical SHA3-256 hash of this transaction.
 func (t *Transaction) ID() Identifier {
-	return HashToID(DefaultHasher.ComputeHash(t.Encode()))
+	return HashToID(defaultEntityHasher.ComputeHash(t.Encode()))
 }
 
 // SetScript sets the Cadence script for this transaction.


### PR DESCRIPTION
Closes: #54

## Description

This PR introduces a thread-safe hasher that can be used to safely compute IDs for Flow entities from multiple routines.
