### PR TITLE
client: Add dedicated error types for RPC and conversion errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -137,8 +137,7 @@ func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*fl
 func getBlockHeaderResult(res *access.BlockHeaderResponse) (*flow.BlockHeader, error) {
 	header, err := convert.MessageToBlockHeader(res.GetBlock())
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityBlockHeader, err)
 	}
 
 	return &header, nil
@@ -192,8 +191,7 @@ func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Blo
 func getBlockResult(res *access.BlockResponse) (*flow.Block, error) {
 	block, err := convert.MessageToBlock(res.GetBlock())
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityBlock, err)
 	}
 
 	return &block, nil
@@ -213,8 +211,7 @@ func (c *Client) GetCollection(ctx context.Context, colID flow.Identifier) (*flo
 
 	result, err := convert.MessageToCollection(res.GetCollection())
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityCollection, err)
 	}
 
 	return &result, nil
@@ -224,8 +221,7 @@ func (c *Client) GetCollection(ctx context.Context, colID flow.Identifier) (*flo
 func (c *Client) SendTransaction(ctx context.Context, tx flow.Transaction) error {
 	txMsg, err := convert.TransactionToMessage(tx)
 	if err != nil {
-		// TODO: improve errors
-		return fmt.Errorf("client: %w", err)
+		return newEntityToMessageError(entityTransaction, err)
 	}
 
 	req := &access.SendTransactionRequest{
@@ -255,8 +251,7 @@ func (c *Client) GetTransaction(ctx context.Context, txID flow.Identifier) (*flo
 
 	result, err := convert.MessageToTransaction(res.GetTransaction())
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityTransaction, err)
 	}
 
 	return &result, nil
@@ -276,8 +271,7 @@ func (c *Client) GetTransactionResult(ctx context.Context, txID flow.Identifier)
 
 	result, err := convert.MessageToTransactionResult(res)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityTransactionResult, err)
 	}
 
 	return &result, nil
@@ -297,8 +291,7 @@ func (c *Client) GetAccount(ctx context.Context, address flow.Address) (*flow.Ac
 
 	account, err := convert.MessageToAccount(res.GetAccount())
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityAccount, err)
 	}
 
 	return &account, nil
@@ -312,7 +305,7 @@ func (c *Client) ExecuteScriptAtLatestBlock(
 
 	args, err := convert.CadenceValuesToMessages(arguments)
 	if err != nil {
-		return nil, fmt.Errorf("convert: %w", err)
+		return nil, newEntityToMessageError(entityCadenceValue, err)
 	}
 
 	req := &access.ExecuteScriptAtLatestBlockRequest{
@@ -340,7 +333,7 @@ func (c *Client) ExecuteScriptAtBlockID(
 
 	args, err := convert.CadenceValuesToMessages(arguments)
 	if err != nil {
-		return nil, err
+		return nil, newEntityToMessageError(entityCadenceValue, err)
 	}
 
 	req := &access.ExecuteScriptAtBlockIDRequest{
@@ -369,7 +362,7 @@ func (c *Client) ExecuteScriptAtBlockHeight(
 
 	args, err := convert.CadenceValuesToMessages(arguments)
 	if err != nil {
-		return nil, err
+		return nil, newEntityToMessageError(entityCadenceValue, err)
 	}
 
 	req := &access.ExecuteScriptAtBlockHeightRequest{
@@ -390,8 +383,7 @@ func (c *Client) ExecuteScriptAtBlockHeight(
 func executeScriptResult(res *access.ExecuteScriptResponse) (cadence.Value, error) {
 	value, err := convert.MessageToCadenceValue(res.GetValue())
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newMessageToEntityError(entityCadenceValue, err)
 	}
 
 	return value, nil
@@ -464,8 +456,7 @@ func getEventsResult(res *access.EventsResponse) ([]BlockEvents, error) {
 		for i, m := range eventMessages {
 			evt, err := convert.MessageToEvent(m)
 			if err != nil {
-				// TODO: improve errors
-				return nil, fmt.Errorf("client: %w", err)
+				return nil, newMessageToEntityError(entityEvent, err)
 			}
 
 			events[i] = evt

--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow/protobuf/go/flow/access"
@@ -97,8 +96,7 @@ func (c *Client) GetLatestBlockHeader(
 
 	res, err := c.rpcClient.GetLatestBlockHeader(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockHeaderResult(res)
@@ -112,8 +110,7 @@ func (c *Client) GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier
 
 	res, err := c.rpcClient.GetBlockHeaderByID(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockHeaderResult(res)
@@ -127,8 +124,7 @@ func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*fl
 
 	res, err := c.rpcClient.GetBlockHeaderByHeight(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockHeaderResult(res)
@@ -151,8 +147,7 @@ func (c *Client) GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block
 
 	res, err := c.rpcClient.GetLatestBlock(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -166,8 +161,7 @@ func (c *Client) GetBlockByID(ctx context.Context, blockID flow.Identifier) (*fl
 
 	res, err := c.rpcClient.GetBlockByID(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -181,8 +175,7 @@ func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Blo
 
 	res, err := c.rpcClient.GetBlockByHeight(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -205,8 +198,7 @@ func (c *Client) GetCollection(ctx context.Context, colID flow.Identifier) (*flo
 
 	res, err := c.rpcClient.GetCollectionByID(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	result, err := convert.MessageToCollection(res.GetCollection())
@@ -230,8 +222,7 @@ func (c *Client) SendTransaction(ctx context.Context, tx flow.Transaction) error
 
 	_, err = c.rpcClient.SendTransaction(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return fmt.Errorf("client: %w", err)
+		return newRPCError(err)
 	}
 
 	return nil
@@ -245,8 +236,7 @@ func (c *Client) GetTransaction(ctx context.Context, txID flow.Identifier) (*flo
 
 	res, err := c.rpcClient.GetTransaction(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	result, err := convert.MessageToTransaction(res.GetTransaction())
@@ -265,8 +255,7 @@ func (c *Client) GetTransactionResult(ctx context.Context, txID flow.Identifier)
 
 	res, err := c.rpcClient.GetTransactionResult(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	result, err := convert.MessageToTransactionResult(res)
@@ -285,8 +274,7 @@ func (c *Client) GetAccount(ctx context.Context, address flow.Address) (*flow.Ac
 
 	res, err := c.rpcClient.GetAccount(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	account, err := convert.MessageToAccount(res.GetAccount())
@@ -315,8 +303,7 @@ func (c *Client) ExecuteScriptAtLatestBlock(
 
 	res, err := c.rpcClient.ExecuteScriptAtLatestBlock(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return executeScriptResult(res)
@@ -344,8 +331,7 @@ func (c *Client) ExecuteScriptAtBlockID(
 
 	res, err := c.rpcClient.ExecuteScriptAtBlockID(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return executeScriptResult(res)
@@ -373,8 +359,7 @@ func (c *Client) ExecuteScriptAtBlockHeight(
 
 	res, err := c.rpcClient.ExecuteScriptAtBlockHeight(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return executeScriptResult(res)
@@ -417,8 +402,7 @@ func (c *Client) GetEventsForHeightRange(ctx context.Context, query EventRangeQu
 
 	res, err := c.rpcClient.GetEventsForHeightRange(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getEventsResult(res)
@@ -437,8 +421,7 @@ func (c *Client) GetEventsForBlockIDs(
 
 	res, err := c.rpcClient.GetEventsForBlockIDs(ctx, req)
 	if err != nil {
-		// TODO: improve errors
-		return nil, fmt.Errorf("client: %w", err)
+		return nil, newRPCError(err)
 	}
 
 	return getEventsResult(res)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -682,6 +682,7 @@ func TestClient_GetEventsForHeightRange(t *testing.T) {
 			StartHeight: 1,
 			EndHeight:   10,
 		})
+
 		assert.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Empty(t, blocks)

--- a/client/errors.go
+++ b/client/errors.go
@@ -2,12 +2,35 @@ package client
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/status"
 )
 
 const errorMessagePrefix = "client: "
 
 func errorMessage(format string, a ...interface{}) string {
 	return errorMessagePrefix + fmt.Sprintf(format, a...)
+}
+
+type RPCError struct {
+	GRPCError error
+}
+
+func newRPCError(gRPCErr error) RPCError {
+	return RPCError{GRPCError: gRPCErr}
+}
+
+func (e RPCError) Error() string {
+	return errorMessage(e.GRPCError.Error())
+}
+
+func (e RPCError) Unwrap() error {
+	return e.GRPCError
+}
+
+func (e RPCError) GRPCStatus() *status.Status {
+	s, _ := status.FromError(e.GRPCError)
+	return s
 }
 
 const (
@@ -26,10 +49,6 @@ type EntityToMessageError struct {
 	Err    error
 }
 
-func (e EntityToMessageError) Error() string {
-	return errorMessage("failed to construct protobuf message from %s entity: %s", e.Entity, e.Err.Error())
-}
-
 func newEntityToMessageError(entity string, err error) EntityToMessageError {
 	return EntityToMessageError{
 		Entity: entity,
@@ -37,13 +56,17 @@ func newEntityToMessageError(entity string, err error) EntityToMessageError {
 	}
 }
 
+func (e EntityToMessageError) Error() string {
+	return errorMessage("failed to construct protobuf message from %s entity: %s", e.Entity, e.Err.Error())
+}
+
+func (e EntityToMessageError) Unwrap() error {
+	return e.Err
+}
+
 type MessageToEntityError struct {
 	Entity string
 	Err    error
-}
-
-func (e MessageToEntityError) Error() string {
-	return errorMessage("failed to construct %s entity from protobuf value: %s", e.Entity, e.Err.Error())
 }
 
 func newMessageToEntityError(entity string, err error) MessageToEntityError {
@@ -51,4 +74,12 @@ func newMessageToEntityError(entity string, err error) MessageToEntityError {
 		Entity: entity,
 		Err:    err,
 	}
+}
+
+func (e MessageToEntityError) Error() string {
+	return errorMessage("failed to construct %s entity from protobuf value: %s", e.Entity, e.Err.Error())
+}
+
+func (e MessageToEntityError) Unwrap() error {
+	return e.Err
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"fmt"
+)
+
+const errorMessagePrefix = "client: "
+
+func errorMessage(format string, a ...interface{}) string {
+	return errorMessagePrefix + fmt.Sprintf(format, a...)
+}
+
+const (
+	entityBlock             = "flow.Block"
+	entityBlockHeader       = "flow.BlockHeader"
+	entityCollection        = "flow.Collection"
+	entityTransaction       = "flow.Transaction"
+	entityTransactionResult = "flow.TransactionResult"
+	entityAccount           = "flow.Account"
+	entityEvent             = "flow.Event"
+	entityCadenceValue      = "cadence.Value"
+)
+
+type EntityToMessageError struct {
+	Entity string
+	Err    error
+}
+
+func (e EntityToMessageError) Error() string {
+	return errorMessage("failed to construct protobuf message from %s entity: %s", e.Entity, e.Err.Error())
+}
+
+func newEntityToMessageError(entity string, err error) EntityToMessageError {
+	return EntityToMessageError{
+		Entity: entity,
+		Err:    err,
+	}
+}
+
+type MessageToEntityError struct {
+	Entity string
+	Err    error
+}
+
+func (e MessageToEntityError) Error() string {
+	return errorMessage("failed to construct %s entity from protobuf value: %s", e.Entity, e.Err.Error())
+}
+
+func newMessageToEntityError(entity string, err error) MessageToEntityError {
+	return MessageToEntityError{
+		Entity: entity,
+		Err:    err,
+	}
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -12,24 +12,30 @@ func errorMessage(format string, a ...interface{}) string {
 	return errorMessagePrefix + fmt.Sprintf(format, a...)
 }
 
+// An RPCError is an error returned by an RPC call to an Access API.
+//
+// An RPC error can be unwrapped to produce the original gRPC error.
 type RPCError struct {
-	GRPCError error
+	GRPCErr error
 }
 
 func newRPCError(gRPCErr error) RPCError {
-	return RPCError{GRPCError: gRPCErr}
+	return RPCError{GRPCErr: gRPCErr}
 }
 
 func (e RPCError) Error() string {
-	return errorMessage(e.GRPCError.Error())
+	return errorMessage(e.GRPCErr.Error())
 }
 
 func (e RPCError) Unwrap() error {
-	return e.GRPCError
+	return e.GRPCErr
 }
 
+// GRPCStatus returns the gRPC status for this error.
+//
+// This function satisfies the interface defined in the status.FromError function.
 func (e RPCError) GRPCStatus() *status.Status {
-	s, _ := status.FromError(e.GRPCError)
+	s, _ := status.FromError(e.GRPCErr)
 	return s
 }
 
@@ -44,6 +50,7 @@ const (
 	entityCadenceValue      = "cadence.Value"
 )
 
+// An EntityToMessageError indicates that an entity could not be converted to a protobuf message.
 type EntityToMessageError struct {
 	Entity string
 	Err    error
@@ -64,6 +71,7 @@ func (e EntityToMessageError) Unwrap() error {
 	return e.Err
 }
 
+// A MessageToEntityError indicates that a protobuf message could not be converted to an SDK entity.
 type MessageToEntityError struct {
 	Entity string
 	Err    error


### PR DESCRIPTION
Closes: #32 

## Description

This PR improves the error values returned by a `client.Client` instance. 

gRPC errors are wrapped in a `client.RPCError` type that can be used as follows:

```go
import "google.golang.org/grpc/status"

res, err := c.GetTransactionResult(...)
if err != nil {
  s, ok := status.FromError(err)
  ...
}
```