### PR TITLE
Rename GetAccount to GetAccountAtLatestBlock

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -266,13 +266,18 @@ func (c *Client) GetTransactionResult(ctx context.Context, txID flow.Identifier)
 	return &result, nil
 }
 
-// GetAccount gets an account by address.
+// GetAccount is an alias for GetAccountAtLatestBlock.
 func (c *Client) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
-	req := &access.GetAccountRequest{
+	return c.GetAccountAtLatestBlock(ctx, address)
+}
+
+// GetAccountAtLatestBlock gets an account by address at the latest sealed block.
+func (c *Client) GetAccountAtLatestBlock(ctx context.Context, address flow.Address) (*flow.Account, error) {
+	req := &access.GetAccountAtLatestBlockRequest{
 		Address: address.Bytes(),
 	}
 
-	res, err := c.rpcClient.GetAccount(ctx, req)
+	res, err := c.rpcClient.GetAccountAtLatestBlock(ctx, req)
 	if err != nil {
 		return nil, newRPCError(err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -402,19 +402,19 @@ func TestClient_GetTransactionResult(t *testing.T) {
 	}))
 }
 
-func TestClient_GetAccount(t *testing.T) {
+func TestClient_GetAccountAtLatestBlock(t *testing.T) {
 	accounts := test.AccountGenerator()
 	addresses := test.AddressGenerator()
 
 	t.Run("Success", clientTest(func(t *testing.T, ctx context.Context, rpc *MockRPCClient, c *client.Client) {
 		expectedAccount := accounts.New()
-		response := &access.GetAccountResponse{
+		response := &access.AccountResponse{
 			Account: convert.AccountToMessage(*expectedAccount),
 		}
 
-		rpc.On("GetAccount", ctx, mock.Anything).Return(response, nil)
+		rpc.On("GetAccountAtLatestBlock", ctx, mock.Anything).Return(response, nil)
 
-		account, err := c.GetAccount(ctx, expectedAccount.Address)
+		account, err := c.GetAccountAtLatestBlock(ctx, expectedAccount.Address)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedAccount, account)
@@ -423,10 +423,10 @@ func TestClient_GetAccount(t *testing.T) {
 	t.Run("Not found error", clientTest(func(t *testing.T, ctx context.Context, rpc *MockRPCClient, c *client.Client) {
 		address := addresses.New()
 
-		rpc.On("GetAccount", ctx, mock.Anything).
+		rpc.On("GetAccountAtLatestBlock", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		account, err := c.GetAccount(ctx, address)
+		account, err := c.GetAccountAtLatestBlock(ctx, address)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, account)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -402,7 +402,7 @@ func TestClient_GetTransactionResult(t *testing.T) {
 	}))
 }
 
-func TestClient_GetAccountAtLatestBlock(t *testing.T) {
+func TestClient_GetAccount(t *testing.T) {
 	accounts := test.AccountGenerator()
 	addresses := test.AddressGenerator()
 

--- a/client/mock_client_test.go
+++ b/client/mock_client_test.go
@@ -107,8 +107,8 @@ func (_m *MockRPCClient) ExecuteScriptAtLatestBlock(ctx context.Context, in *acc
 	return r0, r1
 }
 
-// GetAccount provides a mock function with given fields: ctx, in, opts
-func (_m *MockRPCClient) GetAccount(ctx context.Context, in *access.GetAccountRequest, opts ...grpc.CallOption) (*access.GetAccountResponse, error) {
+// GetAccountAtBlockHeight provides a mock function with given fields: ctx, in, opts
+func (_m *MockRPCClient) GetAccountAtBlockHeight(ctx context.Context, in *access.GetAccountAtBlockHeightRequest, opts ...grpc.CallOption) (*access.AccountResponse, error) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -118,17 +118,47 @@ func (_m *MockRPCClient) GetAccount(ctx context.Context, in *access.GetAccountRe
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
-	var r0 *access.GetAccountResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *access.GetAccountRequest, ...grpc.CallOption) *access.GetAccountResponse); ok {
+	var r0 *access.AccountResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *access.GetAccountAtBlockHeightRequest, ...grpc.CallOption) *access.AccountResponse); ok {
 		r0 = rf(ctx, in, opts...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*access.GetAccountResponse)
+			r0 = ret.Get(0).(*access.AccountResponse)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *access.GetAccountRequest, ...grpc.CallOption) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *access.GetAccountAtBlockHeightRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetAccountAtLatestBlock provides a mock function with given fields: ctx, in, opts
+func (_m *MockRPCClient) GetAccountAtLatestBlock(ctx context.Context, in *access.GetAccountAtLatestBlockRequest, opts ...grpc.CallOption) (*access.AccountResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *access.AccountResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *access.GetAccountAtLatestBlockRequest, ...grpc.CallOption) *access.AccountResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*access.AccountResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *access.GetAccountAtLatestBlockRequest, ...grpc.CallOption) error); ok {
 		r1 = rf(ctx, in, opts...)
 	} else {
 		r1 = ret.Error(1)

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,9 @@ require (
 	github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd
 	github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27
 	github.com/pkg/errors v0.8.1
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/vektra/mockery v1.1.2 // indirect
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
+	golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e // indirect
 	google.golang.org/grpc v1.28.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,10 @@ require (
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/lithammer/dedent v1.1.0
 	github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd
-	github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca
+	github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27
 	github.com/pkg/errors v0.8.1
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1
+	github.com/vektra/mockery v1.1.2 // indirect
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
-	golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e // indirect
 	google.golang.org/grpc v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -137,9 +137,6 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd h1:MYPhW5wojW1wlIncBN6Atsi+aC9FPUcCJcURADcmzsk=
 github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd/go.mod h1:dgj1JPlSDeY6ZSqD/yCW06reFSt+19d/IFgQ1eE8Bfg=
-github.com/onflow/flow v0.1.4-0.20200619174948-a3a856d16a27 h1:SJ3N+6dEwpQYbr0ZZVdNNDNWOSZktdDsSw8x4NDD6qc=
-github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca h1:iw0VQx3aic04XPqpgJfw3CmHpkflK5vEb6EHi/hBsk8=
-github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:ZZ8njaFTOz7JyBpQwXGfFUUOc9l2urVAxQ7FpMUpfnc=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -193,8 +190,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
-github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,11 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd h1:MYPhW5wojW1wlIncBN6Atsi+aC9FPUcCJcURADcmzsk=
 github.com/onflow/cadence v0.4.1-0.20200604185918-21edaa9bfcdd/go.mod h1:dgj1JPlSDeY6ZSqD/yCW06reFSt+19d/IFgQ1eE8Bfg=
+github.com/onflow/flow v0.1.4-0.20200619174948-a3a856d16a27 h1:SJ3N+6dEwpQYbr0ZZVdNNDNWOSZktdDsSw8x4NDD6qc=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca h1:iw0VQx3aic04XPqpgJfw3CmHpkflK5vEb6EHi/hBsk8=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200611205353-548107cc9aca/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:ZZ8njaFTOz7JyBpQwXGfFUUOc9l2urVAxQ7FpMUpfnc=
+github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -190,6 +193,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
+github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=


### PR DESCRIPTION
Closes: #63 63

## Description

Access API method `GetAccount` has been renamed to `GetAccountAtLatestBlock`. This change is for updating `flow-go-sdk` to the latest Access Node API.

______

For contributor use:

- [X] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
