### PR TITLE
Add RawArgument and Argument functions to flow.Transaction

### DIFF
--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -345,16 +345,6 @@ func MessagesToIdentifiers(l [][]byte) []flow.Identifier {
 }
 
 func TransactionToMessage(t flow.Transaction) (*entities.Transaction, error) {
-	var err error
-
-	arguments := make([][]byte, len(t.Arguments))
-	for i, arg := range t.Arguments {
-		arguments[i], err = CadenceValueToMessage(arg)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	proposalKeyMessage := &entities.Transaction_ProposalKey{
 		Address:        t.ProposalKey.Address.Bytes(),
 		KeyId:          uint32(t.ProposalKey.KeyID),
@@ -388,7 +378,7 @@ func TransactionToMessage(t flow.Transaction) (*entities.Transaction, error) {
 
 	return &entities.Transaction{
 		Script:             t.Script,
-		Arguments:          arguments,
+		Arguments:          t.Arguments,
 		ReferenceBlockId:   t.ReferenceBlockID.Bytes(),
 		GasLimit:           t.GasLimit,
 		ProposalKey:        proposalKeyMessage,
@@ -411,12 +401,7 @@ func MessageToTransaction(m *entities.Transaction) (flow.Transaction, error) {
 	t.SetGasLimit(m.GetGasLimit())
 
 	for _, arg := range m.GetArguments() {
-		value, err := MessageToCadenceValue(arg)
-		if err != nil {
-			return flow.Transaction{}, err
-		}
-
-		t.AddArgument(value)
+		t.AddRawArgument(arg)
 	}
 
 	proposalKey := m.GetProposalKey()

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -227,20 +227,6 @@ func TestConvert_Transaction(t *testing.T) {
 
 		assert.Equal(t, txA.ID(), txB.ID())
 	})
-
-	t.Run("With invalid arguments", func(t *testing.T) {
-		txA := test.TransactionGenerator().New()
-
-		msg, err := convert.TransactionToMessage(*txA)
-		require.NoError(t, err)
-
-		// invalid JSON-CDC
-		msg.Arguments = [][]byte{{1, 2, 3}}
-
-		txB, err := convert.MessageToTransaction(msg)
-		assert.Error(t, err)
-		assert.Equal(t, flow.Transaction{}, txB)
-	})
 }
 
 func TestConvert_TransactionResult(t *testing.T) {

--- a/examples/transaction_arguments/main.go
+++ b/examples/transaction_arguments/main.go
@@ -47,9 +47,11 @@ func TransactionArgumentsDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript(test.GreetingScript).
-		AddArgument(greeting).
 		SetProposalKey(serviceAcctAddr, serviceAcctKey.ID, serviceAcctKey.SequenceNumber).
 		SetPayer(serviceAcctAddr)
+
+	err = tx.AddArgument(greeting)
+	examples.Handle(err)
 
 	fmt.Println("Sending transaction:")
 	fmt.Println()

--- a/test/entities.go
+++ b/test/entities.go
@@ -326,14 +326,20 @@ func (g *Transactions) NewUnsigned() *flow.Transaction {
 
 	proposalKey := accountA.Keys[0]
 
-	return flow.NewTransaction().
+	tx := flow.NewTransaction().
 		SetScript(GreetingScript).
-		AddArgument(cadence.NewString(g.greetings.New())).
 		SetReferenceBlockID(blockID).
 		SetGasLimit(42).
 		SetProposalKey(accountA.Address, proposalKey.ID, proposalKey.SequenceNumber).
 		AddAuthorizer(accountA.Address).
 		SetPayer(accountB.Address)
+
+	err := tx.AddArgument(cadence.NewString(g.greetings.New()))
+	if err != nil {
+		panic(err)
+	}
+
+	return tx
 }
 
 type TransactionResults struct {

--- a/transaction.go
+++ b/transaction.go
@@ -58,15 +58,14 @@ func (t *Transaction) SetScript(script []byte) *Transaction {
 }
 
 // AddArgument adds a Cadence argument to this transaction.
-func (t *Transaction) AddArgument(arg cadence.Value) *Transaction {
+func (t *Transaction) AddArgument(arg cadence.Value) error {
 	encodedArg, err := jsoncdc.Encode(arg)
 	if err != nil {
-		// argument is not added if encoding fails
-		return t
+		return fmt.Errorf("failed to encode argument: %w", err)
 	}
 
 	t.Arguments = append(t.Arguments, encodedArg)
-	return t
+	return nil
 }
 
 // AddRawArgument adds a raw JSON-CDC encoded argument to this transaction.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -145,8 +145,10 @@ func TestTransaction_AddArgument(t *testing.T) {
 	t.Run("Single argument", func(t *testing.T) {
 		expectedArg := cadence.NewString("foo")
 
-		tx := flow.NewTransaction().
-			AddArgument(expectedArg)
+		tx := flow.NewTransaction()
+
+		err := tx.AddArgument(expectedArg)
+		require.NoError(t, err)
 
 		actualArg, err := tx.Argument(0)
 		assert.NoError(t, err)
@@ -158,9 +160,12 @@ func TestTransaction_AddArgument(t *testing.T) {
 		expectedArgA := cadence.NewString("foo")
 		expectedArgB := cadence.NewInt(42)
 
-		tx := flow.NewTransaction().
-			AddArgument(expectedArgA).
-			AddArgument(expectedArgB)
+		tx := flow.NewTransaction()
+
+		err := tx.AddArgument(expectedArgA)
+		require.NoError(t, err)
+		err = tx.AddArgument(expectedArgB)
+		require.NoError(t, err)
 
 		actualArgA, err := tx.Argument(0)
 		assert.NoError(t, err)
@@ -518,13 +523,15 @@ func TestTransaction_RLPMessages(t *testing.T) {
 		},
 		{
 			name:     "Single argument",
-			tx:       baseTx().AddArgument(cadence.NewString("foo")),
+			tx:       baseTx().AddRawArgument(jsoncdc.MustEncode(cadence.NewString("foo"))),
 			payload:  "f893b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207de1a07b2274797065223a22537472696e67222c2276616c7565223a22666f6f227d0aa0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001",
 			envelope: "f8baf893b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207de1a07b2274797065223a22537472696e67222c2276616c7565223a22666f6f227d0aa0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001e4e38004a0f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162",
 		},
 		{
-			name:     "Multiple arguments",
-			tx:       baseTx().AddArgument(cadence.NewString("foo")).AddArgument(cadence.NewInt(42)),
+			name: "Multiple arguments",
+			tx: baseTx().
+				AddRawArgument(jsoncdc.MustEncode(cadence.NewString("foo"))).
+				AddRawArgument(jsoncdc.MustEncode(cadence.NewInt(42))),
 			payload:  "f8b1b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207df83ea07b2274797065223a22537472696e67222c2276616c7565223a22666f6f227d0a9c7b2274797065223a22496e74222c2276616c7565223a223432227d0aa0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001",
 			envelope: "f8d8f8b1b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207df83ea07b2274797065223a22537472696e67222c2276616c7565223a22666f6f227d0a9c7b2274797065223a22496e74222c2276616c7565223a223432227d0aa0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001e4e38004a0f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162",
 		},

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -142,22 +143,83 @@ func TestTransaction_AddArgument(t *testing.T) {
 	})
 
 	t.Run("Single argument", func(t *testing.T) {
-		arg := cadence.NewString("foo")
-		tx := flow.NewTransaction().
-			AddArgument(arg)
+		expectedArg := cadence.NewString("foo")
 
-		assert.Equal(t, []cadence.Value{arg}, tx.Arguments)
+		tx := flow.NewTransaction().
+			AddArgument(expectedArg)
+
+		actualArg, err := tx.Argument(0)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedArg, actualArg)
 	})
 
 	t.Run("Multiple arguments", func(t *testing.T) {
-		argA := cadence.NewString("foo")
-		argB := cadence.NewInt(42)
+		expectedArgA := cadence.NewString("foo")
+		expectedArgB := cadence.NewInt(42)
 
 		tx := flow.NewTransaction().
-			AddArgument(argA).
-			AddArgument(argB)
+			AddArgument(expectedArgA).
+			AddArgument(expectedArgB)
 
-		assert.Equal(t, []cadence.Value{argA, argB}, tx.Arguments)
+		actualArgA, err := tx.Argument(0)
+		assert.NoError(t, err)
+
+		actualArgB, err := tx.Argument(1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedArgA, actualArgA)
+		assert.Equal(t, expectedArgB, actualArgB)
+	})
+}
+
+func TestTransaction_AddRawArgument(t *testing.T) {
+	t.Run("Single argument", func(t *testing.T) {
+		expectedArg := cadence.NewString("foo")
+
+		encodedArg, err := jsoncdc.Encode(expectedArg)
+		require.NoError(t, err)
+
+		tx := flow.NewTransaction().
+			AddRawArgument(encodedArg)
+
+		actualArg, err := tx.Argument(0)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedArg, actualArg)
+	})
+
+	t.Run("Multiple arguments", func(t *testing.T) {
+		expectedArgA := cadence.NewString("foo")
+		expectedArgB := cadence.NewInt(42)
+
+		encodedArgA, err := jsoncdc.Encode(expectedArgA)
+		require.NoError(t, err)
+
+		encodedArgB, err := jsoncdc.Encode(expectedArgB)
+		require.NoError(t, err)
+
+		tx := flow.NewTransaction().
+			AddRawArgument(encodedArgA).
+			AddRawArgument(encodedArgB)
+
+		actualArgA, err := tx.Argument(0)
+		assert.NoError(t, err)
+
+		actualArgB, err := tx.Argument(1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedArgA, actualArgA)
+		assert.Equal(t, expectedArgB, actualArgB)
+	})
+
+	t.Run("Invalid argument", func(t *testing.T) {
+		tx := flow.NewTransaction().
+			AddRawArgument([]byte{1, 2, 3})
+
+		actualArg, err := tx.Argument(0)
+		assert.Nil(t, actualArg)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Closes: #66 

## Description

This PR introduces a change to the way transaction arguments are stored on the `flow.Transaction` data type.

Because the _encoded_ arguments are used to determine the transaction hash, they must stay consistent across different representations of the same transaction. For example, when decoding a transaction from protobuf, we need to ensure that the original argument encoding is preserved in order to generate the same transaction hash.

Previously the `flow.Transaction` type was not lossless with regards to transaction arguments; by choosing to store arguments as `cadence.Value` types, we forced users of `flow.Transaction` to lose the original encoding (i.e. changes in JSON whitespace, indentation, etc).

This PR updates `flow.Transaction` to store arguments as raw bytes. 

- `AddArgument(arg)` can be used to add a `cadence.Value` argument
- `AddRawArgument(arg)` can be used to add a raw argument
- `Argument(i)` can be used to get an argument as a `cadence.Value` 