### PR TITLE
Update user signature example to encode values

### DIFF
--- a/examples/user_signature/main.go
+++ b/examples/user_signature/main.go
@@ -75,9 +75,9 @@ pub fun main(
     j = j + 1
   }
 
-  let message = toAddress.toBytes().
-    concat(fromAddress.toBytes()).
-    concat(amount.toBigEndianBytes())
+  let message = toAddress.toBytes()
+    .concat(fromAddress.toBytes())
+    .concat(amount.toBigEndianBytes())
 
   return keyList.isValid(
     signatureSet: signatureSet,

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.5.0 h1:OnGQGjO3Axe+iMI/f1KI7PQS1vNFtQmIrdicgdvSy6A=
 github.com/onflow/cadence v0.5.0/go.mod h1:dgj1JPlSDeY6ZSqD/yCW06reFSt+19d/IFgQ1eE8Bfg=
+github.com/onflow/cadence v0.5.0-beta4 h1:m3r4mEdHyfXyqDovgD5QaFQk4cZgD8CRsAjsHEGNwbY=
+github.com/onflow/cadence v0.5.0-beta4/go.mod h1:dgj1JPlSDeY6ZSqD/yCW06reFSt+19d/IFgQ1eE8Bfg=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:ZZ8njaFTOz7JyBpQwXGfFUUOc9l2urVAxQ7FpMUpfnc=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,6 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.5.0 h1:OnGQGjO3Axe+iMI/f1KI7PQS1vNFtQmIrdicgdvSy6A=
 github.com/onflow/cadence v0.5.0/go.mod h1:dgj1JPlSDeY6ZSqD/yCW06reFSt+19d/IFgQ1eE8Bfg=
-github.com/onflow/cadence v0.5.0-beta4 h1:m3r4mEdHyfXyqDovgD5QaFQk4cZgD8CRsAjsHEGNwbY=
-github.com/onflow/cadence v0.5.0-beta4/go.mod h1:dgj1JPlSDeY6ZSqD/yCW06reFSt+19d/IFgQ1eE8Bfg=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:ZZ8njaFTOz7JyBpQwXGfFUUOc9l2urVAxQ7FpMUpfnc=
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
This PR updates the `user_signature` example to reconstruct the signed message using the newly added `toBytes` and `toBigEndianBytes` functions.