### PR TITLE
added example that uses 2 authorisers

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ key3Signer := getSignerForKey3()
 tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
-            prepare(signer: AuthAccount, signer2:AuthAccount) {
+            prepare(signer1: AuthAccount, signer2: AuthAccount) {
               log(signer.address)
               log(signer2.address)
           }

--- a/README.md
+++ b/README.md
@@ -318,9 +318,9 @@ tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
             prepare(signer: AuthAccount, signer2:AuthAccount) {
-						  log(signer.address)
-						  log(signer2.address)
-						}
+              log(signer.address)
+              log(signer2.address)
+          }
         }
     `)).
     SetGasLimit(100).

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ err = tx.SignEnvelope(account2.Address, key3.ID, key3Signer)
 [Full Runnable Example](/examples#multiple-parties)
 
 ---
-##### [Multiple parties with 2 authorizers](https://github.com/onflow/flow/blob/master/docs/accounts-and-keys.md#multiple-parties)
+##### [Multiple parties, two authorizers](https://github.com/onflow/flow/blob/master/docs/accounts-and-keys.md#multiple-parties)
 
 - Proposer and authorizer are the same account (`0x01`).
 - Payer is a separate account (`0x02`).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Flow is a new blockchain for open worlds. Read more about it [here](https://gith
       - [Single party, single signature](#single-party-single-signature)
       - [Single party, multiple signatures](#single-party-multiple-signatures)
       - [Multiple parties](#multiple-parties)
+      - [Multiple parties, two autorizers](#multiple-parties-two-autorizers)
       - [Multiple parties, multiple signatures](#multiple-parties-multiple-signatures)
   - [Sending a Transaction](#sending-a-transaction)
   - [Querying Transaction Results](#querying-transaction-results)
@@ -316,7 +317,7 @@ key3Signer := getSignerForKey3()
 
 tx := flow.NewTransaction().
     SetScript([]byte(`
-        transaction {
+        transaction { 
             prepare(signer: AuthAccount) { log(signer.address) }
         }
     `)).

--- a/README.md
+++ b/README.md
@@ -297,6 +297,52 @@ err = tx.SignEnvelope(account1.Address, key2.ID, key2Signer)
 - Account `0x01` signs the payload.
 - Account `0x02` signs the envelope.
   - Account `0x02` must sign last since it is the payer.
+
+| Account   | Key ID | Weight |
+|-----------|--------|--------|
+| `0x01`    | 1      | 1.0    |
+| `0x02`    | 3      | 1.0    |
+
+```go
+account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
+account2, _ := c.GetAccount(ctx, flow.HexToAddress("02"))
+
+key1 := account1.Keys[0]
+key3 := account2.Keys[0]
+
+// create signers from securely-stored private keys
+key1Signer := getSignerForKey1()
+key3Signer := getSignerForKey3()
+
+tx := flow.NewTransaction().
+    SetScript([]byte(`
+        transaction {
+            prepare(signer: AuthAccount) { log(signer.address) }
+        }
+    `)).
+    SetGasLimit(100).
+    SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
+    SetPayer(account2.Address).
+    AddAuthorizer(account1.Address)
+
+// account 1 signs the payload with key 1
+err := tx.SignPayload(account1.Address, key1.ID, key1Signer)
+
+// account 2 signs the envelope with key 3
+// note: payer always signs last
+err = tx.SignEnvelope(account2.Address, key3.ID, key3Signer)
+```
+
+[Full Runnable Example](/examples#multiple-parties)
+
+---
+##### [Multiple parties with 2 authorizers](https://github.com/onflow/flow/blob/master/docs/accounts-and-keys.md#multiple-parties)
+
+- Proposer and authorizer are the same account (`0x01`).
+- Payer is a separate account (`0x02`).
+- Account `0x01` signs the payload.
+- Account `0x02` signs the envelope.
+  - Account `0x02` must sign last since it is the payer.
 - Account `0x02` is also an authorizer to show how to include two AuthAccounts into an transaction
 
 | Account   | Key ID | Weight |
@@ -338,7 +384,7 @@ err := tx.SignPayload(account1.Address, key1.ID, key1Signer)
 err = tx.SignEnvelope(account2.Address, key3.ID, key3Signer)
 ```
 
-[Full Runnable Example](/examples#multiple-parties)
+[Full Runnable Example](/examples#multiple-parties-two-authorizers)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -316,14 +316,18 @@ key3Signer := getSignerForKey3()
 
 tx := flow.NewTransaction().
     SetScript([]byte(`
-        transaction { 
-            prepare(signer: AuthAccount) { log(signer.address) }
+        transaction {
+            prepare(signer: AuthAccount, signer2:AuthAccount) {
+						  log(signer.address)
+						  log(signer2.address)
+						}
         }
     `)).
     SetGasLimit(100).
     SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
     SetPayer(account2.Address).
-    AddAuthorizer(account1.Address)
+    AddAuthorizer(account1.Address).
+    AddAuthorizer(account2.Address)
 
 // account 1 signs the payload with key 1
 err := tx.SignPayload(account1.Address, key1.ID, key1Signer)

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ err = tx.SignEnvelope(account1.Address, key2.ID, key2Signer)
 - Account `0x01` signs the payload.
 - Account `0x02` signs the envelope.
   - Account `0x02` must sign last since it is the payer.
+- Account `0x02` is also an authorizer to show how to include two AuthAccounts into an transaction
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -33,6 +33,10 @@ single-party-multisig:
 multi-party:
 	go run ./transaction_signing/multi_party/main.go
 
+.PHONY: multi-party-two-authorizers
+multi-party-two-authorizers:
+	go run ./transaction_signing/multi_party_two_authorizers/main.go
+
 .PHONY: multi-party-multisig
 multi-party-multisig:
 	go run ./transaction_signing/multi_party_multisig/main.go

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ This package contains code samples that interact with the [Flow Emulator](https:
     - [Single Party, Single Signature](#single-party-single-signature)
     - [Single Party, Multiple Signatures](#single-party-multiple-signatures)
     - [Multiple Parties](#multiple-parties)
+    - [Multiple Parties, Two autorizers](#multiple-parties-two-authorizers)
     - [Multiple Parties, Multiple Signatures](#multiple-parties-multiple-signatures)
   - [User Signature](#user-signature)
 
@@ -112,6 +113,15 @@ make single-party-multisig
 ```sh
 make multi-party
 ```
+
+#### Multiple Parties, Two autorizers
+
+[Sign a transaction with multiple accounts and authorize for both of them.](./transaction_signing/multi_party_two_authorizers/main.go)
+
+```sh
+make multi-party-two-authorizers
+```
+
 
 #### Multiple Parties, Multiple Signatures
 

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -64,10 +64,10 @@ func MultiPartySingleSignatureDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
-		transaction { 
-			prepare(signer: AuthAccount) { log(signer.address) }
-		}
-	`)).
+			 transaction { 
+				 prepare(signer: AuthAccount) { log(signer.address) }
+			 }
+		 `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -64,10 +64,10 @@ func MultiPartySingleSignatureDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
-			 transaction { 
-				 prepare(signer: AuthAccount) { log(signer.address) }
-			 }
-		 `)).
+		 transaction { 
+			 prepare(signer: AuthAccount) { log(signer.address) }
+		 }
+	 `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -65,9 +65,7 @@ func MultiPartySingleSignatureDemo() {
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
 		transaction { 
-			prepare(signer: AuthAccount) { 
-				log(signer.address) 
-			}
+			prepare(signer: AuthAccount) { log(signer.address) }
 		}`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -64,10 +64,10 @@ func MultiPartySingleSignatureDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
-		 transaction { 
-			 prepare(signer: AuthAccount) { log(signer.address) }
-		 }
-	 `)).
+            transaction { 
+                prepare(signer: AuthAccount) { log(signer.address) }
+            }
+        `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -65,13 +65,17 @@ func MultiPartySingleSignatureDemo() {
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
             transaction { 
-                prepare(signer: AuthAccount) { log(signer.address) }
+				prepare(signer: AuthAccount, signer2:AuthAccount) { 
+					log(signer.address) 
+					log(signer2.address)
+				}
             }
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).
-		AddAuthorizer(account1.Address)
+		AddAuthorizer(account1.Address).
+		AddAuthorizer(account2.Address)
 
 	// account 1 signs the payload with key 1
 	err = tx.SignPayload(account1.Address, account1.Keys[0].ID, key1Signer)

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -64,13 +64,12 @@ func MultiPartySingleSignatureDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
-            transaction { 
+			transaction { 
 				prepare(signer: AuthAccount, signer2:AuthAccount) { 
 					log(signer.address) 
 					log(signer2.address)
 				}
-            }
-        `)).
+			}`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -66,7 +66,8 @@ func MultiPartySingleSignatureDemo() {
 		SetScript([]byte(`
 		transaction { 
 			prepare(signer: AuthAccount) { log(signer.address) }
-		}`)).
+		}
+	`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -64,12 +64,12 @@ func MultiPartySingleSignatureDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
-			transaction { 
-				prepare(signer: AuthAccount, signer2:AuthAccount) { 
-					log(signer.address) 
-					log(signer2.address)
-				}
-			}`)).
+		transaction { 
+			prepare(signer: AuthAccount, signer2:AuthAccount) { 
+				log(signer.address) 
+				log(signer2.address)
+			}
+		}`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).

--- a/examples/transaction_signing/multi_party_two_authorizers/main.go
+++ b/examples/transaction_signing/multi_party_two_authorizers/main.go
@@ -65,7 +65,7 @@ func MultiPartySingleSignatureDemo() {
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
 		transaction { 
-			prepare(signer: AuthAccount, signer2:AuthAccount) { 
+			prepare(signer1: AuthAccount, signer2: AuthAccount) { 
 				log(signer.address) 
 				log(signer2.address)
 			}

--- a/examples/transaction_signing/multi_party_two_authorizers/main.go
+++ b/examples/transaction_signing/multi_party_two_authorizers/main.go
@@ -65,14 +65,16 @@ func MultiPartySingleSignatureDemo() {
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
 		transaction { 
-			prepare(signer: AuthAccount) { 
+			prepare(signer: AuthAccount, signer2:AuthAccount) { 
 				log(signer.address) 
+				log(signer2.address)
 			}
 		}`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).
-		AddAuthorizer(account1.Address)
+		AddAuthorizer(account1.Address).
+		AddAuthorizer(account2.Address)
 
 	// account 1 signs the payload with key 1
 	err = tx.SignPayload(account1.Address, account1.Keys[0].ID, key1Signer)


### PR DESCRIPTION
I did not make an issue for this should I do that?

## Description

There are no examples on how to get two authorisers in a transaction. This fixes that

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
