### PR TITLE
add expiry transaction status

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -391,5 +391,5 @@ const (
 
 // String returns the string representation of a transaction status.
 func (s TransactionStatus) String() string {
-	return [...]string{"UNKNOWN", "PENDING", "FINALIZED", "EXECUTED", "SEALED"}[s]
+	return [...]string{"UNKNOWN", "PENDING", "FINALIZED", "EXECUTED", "SEALED", "EXPIRED"}[s]
 }


### PR DESCRIPTION

## Description

Expiry string was not added in the String() method of `TransactionStatus` and causes printing of `TransactionStatusExpired` to panic.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
