### PR TITLE
templates: Do not deploy empty code string on account creation

### DIFF
--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -31,10 +31,12 @@ transaction(publicKeys: [[UInt8]], code: [UInt8]) {
 	let acct = AuthAccount(payer: signer)
 
 	for key in publicKeys {
-		acct.addPublicKey(key)
+	  acct.addPublicKey(key)
 	}
-
-	acct.setCode(code)
+	
+	if code.length > 0 {
+	  acct.setCode(code)
+	}
   }
 }
 `


### PR DESCRIPTION
This fixes an inefficiency in the account creation template that was causing a the `setCode` method to always be called, even if there is no code to deploy. 