### PR TITLE
Added BlockTimestamp to BlockEvents response

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,8 @@ package client
 
 import (
 	"context"
+	"github.com/golang/protobuf/ptypes"
+	"time"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow/protobuf/go/flow/access"
@@ -393,6 +395,7 @@ type EventRangeQuery struct {
 type BlockEvents struct {
 	BlockID flow.Identifier
 	Height  uint64
+	BlockTimestamp time.Time
 	Events  []flow.Event
 }
 
@@ -450,10 +453,15 @@ func getEventsResult(res *access.EventsResponse) ([]BlockEvents, error) {
 			events[i] = evt
 		}
 
+		blockTimestamp, err := ptypes.Timestamp(result.BlockTimestamp)
+		if err != nil {
+			return nil, newMessageToEntityError(entityEvent, err)
+		}
 		results[i] = BlockEvents{
-			BlockID: flow.HashToID(result.GetBlockId()),
-			Height:  result.GetBlockHeight(),
-			Events:  events,
+			BlockID:        flow.HashToID(result.GetBlockId()),
+			Height:         result.GetBlockHeight(),
+			BlockTimestamp: blockTimestamp,
+			Events:         events,
 		}
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -20,8 +20,7 @@ package client_test
 
 import (
 	"context"
-	"testing"
-
+	"github.com/golang/protobuf/ptypes"
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow/protobuf/go/flow/access"
@@ -31,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"testing"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
@@ -631,16 +631,18 @@ func TestClient_GetEventsForHeightRange(t *testing.T) {
 			response := &access.EventsResponse{
 				Results: []*access.EventsResponse_Result{
 					{
-						BlockId:     ids.New().Bytes(),
-						BlockHeight: 1,
+						BlockId:        ids.New().Bytes(),
+						BlockHeight:    1,
+						BlockTimestamp: ptypes.TimestampNow(),
 						Events: []*entities.Event{
 							eventAMsg,
 							eventBMsg,
 						},
 					},
 					{
-						BlockId:     ids.New().Bytes(),
-						BlockHeight: 2,
+						BlockId:        ids.New().Bytes(),
+						BlockHeight:    2,
+						BlockTimestamp: ptypes.TimestampNow(),
 						Events: []*entities.Event{
 							eventCMsg,
 							eventDMsg,
@@ -725,16 +727,18 @@ func TestClient_GetEventsForBlockIDs(t *testing.T) {
 			response := &access.EventsResponse{
 				Results: []*access.EventsResponse_Result{
 					{
-						BlockId:     blockIDA.Bytes(),
-						BlockHeight: 1,
+						BlockId:        blockIDA.Bytes(),
+						BlockHeight:    1,
+						BlockTimestamp: ptypes.TimestampNow(),
 						Events: []*entities.Event{
 							eventAMsg,
 							eventBMsg,
 						},
 					},
 					{
-						BlockId:     blockIDB.Bytes(),
-						BlockHeight: 2,
+						BlockId:        blockIDB.Bytes(),
+						BlockHeight:    2,
+						BlockTimestamp: ptypes.TimestampNow(),
 						Events: []*entities.Event{
 							eventCMsg,
 							eventDMsg,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/protobuf v1.3.5
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/onflow/cadence v0.8.0
-	github.com/onflow/flow/protobuf/go/flow v0.1.6
+	github.com/onflow/flow/protobuf/go/flow v0.1.7
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/protobuf v1.3.5
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/onflow/cadence v0.8.0
-	github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597
+	github.com/onflow/flow/protobuf/go/flow v0.1.6
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/protobuf v1.3.5
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/onflow/cadence v0.8.0
-	github.com/onflow/flow/protobuf/go/flow v0.1.5
+	github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/onflow/cadence v0.8.0 h1:7qMjZ3QJBdHZO+/HsxAJaLAXBJWVwT60Zw7t2PmJ/pY=
 github.com/onflow/cadence v0.8.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/flow/protobuf/go/flow v0.1.5 h1:OQJhjreSkzV8nsBpx6yJNtCaGdqe5xYn83IkcFMERGU=
 github.com/onflow/flow/protobuf/go/flow v0.1.5/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597 h1:ok1yH3tpBZE1pLVYHKXxmP4E9uiCDVtUcmXtPJLZRNQ=
+github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -184,6 +186,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
+github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/onflow/flow/protobuf/go/flow v0.1.5 h1:OQJhjreSkzV8nsBpx6yJNtCaGdqe5x
 github.com/onflow/flow/protobuf/go/flow v0.1.5/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597 h1:ok1yH3tpBZE1pLVYHKXxmP4E9uiCDVtUcmXtPJLZRNQ=
 github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.1.6 h1:nUNVpDaZgNwaxhSD41ijK0s4ykR/MrRYuEG4foUXDAo=
+github.com/onflow/flow/protobuf/go/flow v0.1.6/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/go.sum
+++ b/go.sum
@@ -131,12 +131,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.8.0 h1:7qMjZ3QJBdHZO+/HsxAJaLAXBJWVwT60Zw7t2PmJ/pY=
 github.com/onflow/cadence v0.8.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
-github.com/onflow/flow/protobuf/go/flow v0.1.5 h1:OQJhjreSkzV8nsBpx6yJNtCaGdqe5xYn83IkcFMERGU=
-github.com/onflow/flow/protobuf/go/flow v0.1.5/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
-github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597 h1:ok1yH3tpBZE1pLVYHKXxmP4E9uiCDVtUcmXtPJLZRNQ=
-github.com/onflow/flow/protobuf/go/flow v0.1.6-0.20200918135459-967e2d272597/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
-github.com/onflow/flow/protobuf/go/flow v0.1.6 h1:nUNVpDaZgNwaxhSD41ijK0s4ykR/MrRYuEG4foUXDAo=
-github.com/onflow/flow/protobuf/go/flow v0.1.6/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.1.7 h1:BaZVc1XWkI1vx/+qvdkXnKjsWk4UFRBAg7vvfQ/u5Pk=
+github.com/onflow/flow/protobuf/go/flow v0.1.7/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -188,8 +184,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
-github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=


### PR DESCRIPTION
Closes: #99

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Added BlockTimestamp to the access node EventsResponse. This allows you to know when the event was published without re-requesting the block by block id.
