### PR TITLE
Update flow.AccountKey to match latest protocol changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ payer, payerKey, payerSigner := examples.ServiceAccount(c)
 tx := flow.NewTransaction().
     SetScript(script).
     SetGasLimit(100).
-    SetProposalKey(payer, payerKey.ID, payerKey.SequenceNumber).
+    SetProposalKey(payer, payerKey.Index, payerKey.SequenceNumber).
     SetPayer(payer)
 
-err = tx.SignEnvelope(payer, payerKey.ID, payerSigner)
+err = tx.SignEnvelope(payer, payerKey.Index, payerSigner)
 if err != nil {
     panic("failed to sign transaction")
 }
@@ -182,7 +182,7 @@ var (
 tx := flow.NewTransaction().
     SetScript([]byte("transaction { execute { log(\"Hello, World!\") } }")).
     SetGasLimit(100).
-    SetProposalKey(myAddress, myAccountKey.ID, myAccountKey.SequenceNumber).
+    SetProposalKey(myAddress, myAccountKey.Index, myAccountKey.SequenceNumber).
     SetPayer(myAddress)
 ```
 
@@ -198,7 +198,7 @@ and is not limited to in-memory implementations.
 // construct a signer from your private key and configured hash algorithm
 mySigner := crypto.NewInMemorySigner(myPrivateKey, myAccountKey.HashAlgo)
 
-err := tx.SignEnvelope(myAddress, myAccountKey.ID, mySigner)
+err := tx.SignEnvelope(myAddress, myAccountKey.Index, mySigner)
 if err != nil {
     panic("failed to sign transaction")
 }
@@ -236,12 +236,12 @@ tx := flow.NewTransaction().
         }
     `)).
     SetGasLimit(100).
-    SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
+    SetProposalKey(account1.Address, key1.Index, key1.SequenceNumber).
     SetPayer(account1.Address).
     AddAuthorizer(account1.Address)
 
 // account 1 signs the envelope with key 1
-err := tx.SignEnvelope(account1.Address, key1.ID, key1Signer)
+err := tx.SignEnvelope(account1.Address, key1.Index, key1Signer)
 ```
 
 [Full Runnable Example](/examples#single-party-single-signature)
@@ -276,15 +276,15 @@ tx := flow.NewTransaction().
         }
     `)).
     SetGasLimit(100).
-    SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
+    SetProposalKey(account1.Address, key1.Index, key1.SequenceNumber).
     SetPayer(account1.Address).
     AddAuthorizer(account1.Address)
 
 // account 1 signs the envelope with key 1
-err := tx.SignEnvelope(account1.Address, key1.ID, key1Signer)
+err := tx.SignEnvelope(account1.Address, key1.Index, key1Signer)
 
 // account 1 signs the envelope with key 2
-err = tx.SignEnvelope(account1.Address, key2.ID, key2Signer)
+err = tx.SignEnvelope(account1.Address, key2.Index, key2Signer)
 ```
 
 [Full Runnable Example](/examples#single-party-multiple-signatures)
@@ -322,16 +322,16 @@ tx := flow.NewTransaction().
         }
     `)).
     SetGasLimit(100).
-    SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
+    SetProposalKey(account1.Address, key1.Index, key1.SequenceNumber).
     SetPayer(account2.Address).
     AddAuthorizer(account1.Address)
 
 // account 1 signs the payload with key 1
-err := tx.SignPayload(account1.Address, key1.ID, key1Signer)
+err := tx.SignPayload(account1.Address, key1.Index, key1Signer)
 
 // account 2 signs the envelope with key 3
 // note: payer always signs last
-err = tx.SignEnvelope(account2.Address, key3.ID, key3Signer)
+err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 ```
 
 [Full Runnable Example](/examples#multiple-parties)
@@ -372,17 +372,17 @@ tx := flow.NewTransaction().
         }
     `)).
     SetGasLimit(100).
-    SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
+    SetProposalKey(account1.Address, key1.Index, key1.SequenceNumber).
     SetPayer(account2.Address).
     AddAuthorizer(account1.Address).
     AddAuthorizer(account2.Address)
 
 // account 1 signs the payload with key 1
-err := tx.SignPayload(account1.Address, key1.ID, key1Signer)
+err := tx.SignPayload(account1.Address, key1.Index, key1Signer)
 
 // account 2 signs the envelope with key 3
 // note: payer always signs last
-err = tx.SignEnvelope(account2.Address, key3.ID, key3Signer)
+err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 ```
 
 [Full Runnable Example](/examples#multiple-parties-two-authorizers)
@@ -427,23 +427,23 @@ tx := flow.NewTransaction().
         }
     `)).
     SetGasLimit(100).
-    SetProposalKey(account1.Address, key1.ID, key1.SequenceNumber).
+    SetProposalKey(account1.Address, key1.Index, key1.SequenceNumber).
     SetPayer(account2.Address).
     AddAuthorizer(account1.Address)
 
 // account 1 signs the payload with key 1
-err := tx.SignPayload(account1.Address, key1.ID, key1Signer)
+err := tx.SignPayload(account1.Address, key1.Index, key1Signer)
 
 // account 1 signs the payload with key 2
-err = tx.SignPayload(account1.Address, key2.ID, key2Signer)
+err = tx.SignPayload(account1.Address, key2.Index, key2Signer)
 
 // account 2 signs the envelope with key 3
 // note: payer always signs last
-err = tx.SignEnvelope(account2.Address, key3.ID, key3Signer)
+err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 // account 2 signs the envelope with key 4
 // note: payer always signs last
-err = tx.SignEnvelope(account2.Address, key4.ID, key4Signer)
+err = tx.SignEnvelope(account2.Address, key4.Index, key4Signer)
 ```
 
 [Full Runnable Example](/examples#multiple-parties-multiple-signatures)

--- a/account.go
+++ b/account.go
@@ -37,7 +37,7 @@ const AccountKeyWeightThreshold int = 1000
 
 // An AccountKey is a public key associated with an account.
 type AccountKey struct {
-	ID             int
+	Index          int
 	PublicKey      crypto.PublicKey
 	SigAlgo        crypto.SignatureAlgorithm
 	HashAlgo       crypto.HashAlgorithm

--- a/account.go
+++ b/account.go
@@ -43,6 +43,7 @@ type AccountKey struct {
 	HashAlgo       crypto.HashAlgorithm
 	Weight         int
 	SequenceNumber uint64
+	Revoked        bool
 }
 
 // NewAccountKey returns an empty account key.

--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -74,7 +74,7 @@ func MessageToAccount(m *entities.Account) (flow.Account, error) {
 
 func AccountKeyToMessage(a *flow.AccountKey) *entities.AccountKey {
 	return &entities.AccountKey{
-		Index:          uint32(a.ID),
+		Index:          uint32(a.Index),
 		PublicKey:      a.PublicKey.Encode(),
 		SignAlgo:       uint32(a.SigAlgo),
 		HashAlgo:       uint32(a.HashAlgo),
@@ -98,7 +98,7 @@ func MessageToAccountKey(m *entities.AccountKey) (*flow.AccountKey, error) {
 	}
 
 	return &flow.AccountKey{
-		ID:             int(m.GetIndex()),
+		Index:          int(m.GetIndex()),
 		PublicKey:      publicKey,
 		SigAlgo:        sigAlgo,
 		HashAlgo:       hashAlgo,
@@ -349,7 +349,7 @@ func MessagesToIdentifiers(l [][]byte) []flow.Identifier {
 func TransactionToMessage(t flow.Transaction) (*entities.Transaction, error) {
 	proposalKeyMessage := &entities.Transaction_ProposalKey{
 		Address:        t.ProposalKey.Address.Bytes(),
-		KeyId:          uint32(t.ProposalKey.KeyID),
+		KeyId:          uint32(t.ProposalKey.KeyIndex),
 		SequenceNumber: t.ProposalKey.SequenceNumber,
 	}
 
@@ -363,7 +363,7 @@ func TransactionToMessage(t flow.Transaction) (*entities.Transaction, error) {
 	for i, sig := range t.PayloadSignatures {
 		payloadSigMessages[i] = &entities.Transaction_Signature{
 			Address:   sig.Address.Bytes(),
-			KeyId:     uint32(sig.KeyID),
+			KeyId:     uint32(sig.KeyIndex),
 			Signature: sig.Signature,
 		}
 	}
@@ -373,7 +373,7 @@ func TransactionToMessage(t flow.Transaction) (*entities.Transaction, error) {
 	for i, sig := range t.EnvelopeSignatures {
 		envelopeSigMessages[i] = &entities.Transaction_Signature{
 			Address:   sig.Address.Bytes(),
-			KeyId:     uint32(sig.KeyID),
+			KeyId:     uint32(sig.KeyIndex),
 			Signature: sig.Signature,
 		}
 	}

--- a/client/convert/protobuf.go
+++ b/client/convert/protobuf.go
@@ -80,6 +80,7 @@ func AccountKeyToMessage(a *flow.AccountKey) *entities.AccountKey {
 		HashAlgo:       uint32(a.HashAlgo),
 		Weight:         uint32(a.Weight),
 		SequenceNumber: uint32(a.SequenceNumber),
+		Revoked:        a.Revoked,
 	}
 }
 
@@ -103,6 +104,7 @@ func MessageToAccountKey(m *entities.AccountKey) (*flow.AccountKey, error) {
 		HashAlgo:       hashAlgo,
 		Weight:         int(m.GetWeight()),
 		SequenceNumber: uint64(m.GetSequenceNumber()),
+		Revoked:        m.GetRevoked(),
 	}, nil
 }
 

--- a/examples/add_account_key/main.go
+++ b/examples/add_account_key/main.go
@@ -52,11 +52,11 @@ func AddAccountKeyDemo() {
 
 	addKeyTx := templates.AddAccountKey(acctAddr, myAcctKey)
 
-	addKeyTx.SetProposalKey(acctAddr, acctKey.ID, acctKey.SequenceNumber)
+	addKeyTx.SetProposalKey(acctAddr, acctKey.Index, acctKey.SequenceNumber)
 	addKeyTx.SetPayer(acctAddr)
 
 	// Sign the transaction with the new account.
-	err = addKeyTx.SignEnvelope(acctAddr, acctKey.ID, acctSigner)
+	err = addKeyTx.SignEnvelope(acctAddr, acctKey.Index, acctSigner)
 	examples.Handle(err)
 
 	// Send the transaction to the network.

--- a/examples/create_account/main.go
+++ b/examples/create_account/main.go
@@ -51,14 +51,14 @@ func CreateAccountDemo() {
 	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
-		serviceAcctKey.ID,
+		serviceAcctKey.Index,
 		serviceAcctKey.SequenceNumber,
 	)
 	createAccountTx.SetPayer(serviceAcctAddr)
 
 	// Sign the transaction with the service account, which already exists
 	// All new accounts must be created by an existing account
-	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.ID, serviceSigner)
+	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
 	examples.Handle(err)
 
 	// Send the transaction to the network

--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -57,12 +57,12 @@ func DeployContractDemo() {
 	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
-		serviceAcctKey.ID,
+		serviceAcctKey.Index,
 		serviceAcctKey.SequenceNumber,
 	)
 	createAccountTx.SetPayer(serviceAcctAddr)
 
-	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.ID, serviceSigner)
+	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *createAccountTx)
@@ -89,12 +89,12 @@ func DeployContractDemo() {
 	nftCode := examples.ReadFile(GreatTokenContractFile)
 	deployContractTx := templates.CreateAccount(nil, nftCode, myAddress)
 
-	deployContractTx.SetProposalKey(myAddress, myAcctKey.ID, myAcctKey.SequenceNumber)
+	deployContractTx.SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber)
 	deployContractTx.SetPayer(myAddress)
 
 	err = deployContractTx.SignEnvelope(
 		myAddress,
-		myAcctKey.ID,
+		myAcctKey.Index,
 		crypto.NewInMemorySigner(myPrivateKey, myAcctKey.HashAlgo),
 	)
 	examples.Handle(err)
@@ -124,11 +124,11 @@ func DeployContractDemo() {
 
 	createMinterTx := flow.NewTransaction().
 		SetScript(createMinterScript).
-		SetProposalKey(myAddress, myAcctKey.ID, myAcctKey.SequenceNumber).
+		SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber).
 		SetPayer(myAddress).
 		AddAuthorizer(myAddress)
 
-	err = createMinterTx.SignEnvelope(myAddress, myAcctKey.ID, mySigner)
+	err = createMinterTx.SignEnvelope(myAddress, myAcctKey.Index, mySigner)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *createMinterTx)
@@ -145,11 +145,11 @@ func DeployContractDemo() {
 	// Mint the NFT
 	mintTx := flow.NewTransaction().
 		SetScript(mintScript).
-		SetProposalKey(myAddress, myAcctKey.ID, myAcctKey.SequenceNumber).
+		SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber).
 		SetPayer(myAddress).
 		AddAuthorizer(myAddress)
 
-	err = mintTx.SignEnvelope(myAddress, myAcctKey.ID, mySigner)
+	err = mintTx.SignEnvelope(myAddress, myAcctKey.Index, mySigner)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *mintTx)

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -153,10 +153,10 @@ func CreateAccount(flowClient *client.Client, publicKeys []*flow.AccountKey, cod
 
 	createAccountTx := templates.CreateAccount(publicKeys, code, serviceAcctAddr)
 	createAccountTx.
-		SetProposalKey(serviceAcctAddr, serviceAcctKey.ID, serviceAcctKey.SequenceNumber).
+		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
 		SetPayer(serviceAcctAddr)
 
-	err := createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.ID, serviceSigner)
+	err := createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
 	Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *createAccountTx)

--- a/examples/query_events/main.go
+++ b/examples/query_events/main.go
@@ -69,9 +69,9 @@ func QueryEventsDemo() {
 	runScriptTx := flow.NewTransaction().
 		SetScript([]byte(script)).
 		SetPayer(acctAddr).
-		SetProposalKey(acctAddr, acctKey.ID, acctKey.SequenceNumber)
+		SetProposalKey(acctAddr, acctKey.Index, acctKey.SequenceNumber)
 
-	err = runScriptTx.SignEnvelope(acctAddr, acctKey.ID, acctSigner)
+	err = runScriptTx.SignEnvelope(acctAddr, acctKey.Index, acctSigner)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *runScriptTx)

--- a/examples/transaction_arguments/main.go
+++ b/examples/transaction_arguments/main.go
@@ -47,7 +47,7 @@ func TransactionArgumentsDemo() {
 
 	tx := flow.NewTransaction().
 		SetScript(test.GreetingScript).
-		SetProposalKey(serviceAcctAddr, serviceAcctKey.ID, serviceAcctKey.SequenceNumber).
+		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
 		SetPayer(serviceAcctAddr)
 
 	err = tx.AddArgument(greeting)
@@ -63,7 +63,7 @@ func TransactionArgumentsDemo() {
 	fmt.Println("----------------")
 	fmt.Println()
 
-	err = tx.SignEnvelope(serviceAcctAddr, serviceAcctKey.ID, serviceSigner)
+	err = tx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *tx)

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -69,16 +69,16 @@ func MultiPartySingleSignatureDemo() {
             }
         `)).
 		SetGasLimit(100).
-		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
+		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address)
 
 	// account 1 signs the payload with key 1
-	err = tx.SignPayload(account1.Address, account1.Keys[0].ID, key1Signer)
+	err = tx.SignPayload(account1.Address, account1.Keys[0].Index, key1Signer)
 	examples.Handle(err)
 
 	// account 2 signs the envelope with key 3
-	err = tx.SignEnvelope(account2.Address, account2.Keys[0].ID, key3Signer)
+	err = tx.SignEnvelope(account2.Address, account2.Keys[0].Index, key3Signer)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *tx)

--- a/examples/transaction_signing/multi_party_multisig/main.go
+++ b/examples/transaction_signing/multi_party_multisig/main.go
@@ -87,24 +87,24 @@ func MultiPartyMultiSignatureDemo() {
             }
         `)).
 		SetGasLimit(100).
-		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
+		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address)
 
 	// account 1 signs the payload with key 1
-	err = tx.SignPayload(account1.Address, account1.Keys[0].ID, key1Signer)
+	err = tx.SignPayload(account1.Address, account1.Keys[0].Index, key1Signer)
 	examples.Handle(err)
 
 	// account 1 signs the payload with key 2
-	err = tx.SignPayload(account1.Address, account1.Keys[1].ID, key2Signer)
+	err = tx.SignPayload(account1.Address, account1.Keys[1].Index, key2Signer)
 	examples.Handle(err)
 
 	// account 2 signs the envelope with key 3
-	err = tx.SignEnvelope(account2.Address, account2.Keys[0].ID, key3Signer)
+	err = tx.SignEnvelope(account2.Address, account2.Keys[0].Index, key3Signer)
 	examples.Handle(err)
 
 	// account 2 signs the envelope with key 4
-	err = tx.SignEnvelope(account2.Address, account2.Keys[1].ID, key4Signer)
+	err = tx.SignEnvelope(account2.Address, account2.Keys[1].Index, key4Signer)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *tx)

--- a/examples/transaction_signing/multi_party_two_authorizers/main.go
+++ b/examples/transaction_signing/multi_party_two_authorizers/main.go
@@ -71,17 +71,17 @@ func MultiPartySingleSignatureDemo() {
 			}
 		}`)).
 		SetGasLimit(100).
-		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
+		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address).
 		AddAuthorizer(account2.Address)
 
 	// account 1 signs the payload with key 1
-	err = tx.SignPayload(account1.Address, account1.Keys[0].ID, key1Signer)
+	err = tx.SignPayload(account1.Address, account1.Keys[0].Index, key1Signer)
 	examples.Handle(err)
 
 	// account 2 signs the envelope with key 3
-	err = tx.SignEnvelope(account2.Address, account2.Keys[0].ID, key3Signer)
+	err = tx.SignEnvelope(account2.Address, account2.Keys[0].Index, key3Signer)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *tx)

--- a/examples/transaction_signing/single_party/main.go
+++ b/examples/transaction_signing/single_party/main.go
@@ -59,12 +59,12 @@ func SinglePartySingleSignatureDemo() {
             }
         `)).
 		SetGasLimit(100).
-		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
+		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
 		SetPayer(account1.Address).
 		AddAuthorizer(account1.Address)
 
 	// account 1 signs the envelope with key 1
-	err = tx.SignEnvelope(account1.Address, account1.Keys[0].ID, key1Signer)
+	err = tx.SignEnvelope(account1.Address, account1.Keys[0].Index, key1Signer)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *tx)

--- a/examples/transaction_signing/single_party_multisig/main.go
+++ b/examples/transaction_signing/single_party_multisig/main.go
@@ -68,16 +68,16 @@ func SinglePartyMultiSignatureDemo() {
             }
         `)).
 		SetGasLimit(100).
-		SetProposalKey(account1.Address, account1.Keys[0].ID, account1.Keys[0].SequenceNumber).
+		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
 		SetPayer(account1.Address).
 		AddAuthorizer(account1.Address)
 
 	// account 1 signs the envelope with key 1
-	err = tx.SignEnvelope(account1.Address, account1.Keys[0].ID, key1Signer)
+	err = tx.SignEnvelope(account1.Address, account1.Keys[0].Index, key1Signer)
 	examples.Handle(err)
 
 	// account 1 signs the envelope with key 2
-	err = tx.SignEnvelope(account1.Address, account1.Keys[1].ID, key2Signer)
+	err = tx.SignEnvelope(account1.Address, account1.Keys[1].Index, key2Signer)
 	examples.Handle(err)
 
 	err = flowClient.SendTransaction(ctx, *tx)

--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -101,20 +101,20 @@ func AddAccountKey(address flow.Address, accountKey *flow.AccountKey) *flow.Tran
 }
 
 const removeAccountKeyTemplate = `
-transaction(keyID: Int) {
+transaction(keyIndex: Int) {
   prepare(signer: AuthAccount) {
-    signer.removePublicKey(keyID)
+    signer.removePublicKey(keyIndex)
   }	
 }
 `
 
 // RemoveAccountKey generates a transaction that removes a key from an account.
-func RemoveAccountKey(address flow.Address, keyID int) *flow.Transaction {
-	cadenceKeyID := cadence.NewInt(keyID)
+func RemoveAccountKey(address flow.Address, keyIndex int) *flow.Transaction {
+	cadenceKeyIndex := cadence.NewInt(keyIndex)
 
 	return flow.NewTransaction().
 		SetScript([]byte(removeAccountKeyTemplate)).
-		AddRawArgument(jsoncdc.MustEncode(cadenceKeyID)).
+		AddRawArgument(jsoncdc.MustEncode(cadenceKeyIndex)).
 		AddAuthorizer(address)
 }
 

--- a/test/entities.go
+++ b/test/entities.go
@@ -85,7 +85,7 @@ func (g *AccountKeys) NewWithSigner() (*flow.AccountKey, crypto.Signer) {
 	}
 
 	accountKey := flow.AccountKey{
-		ID:             g.count,
+		Index:          g.count,
 		PublicKey:      privateKey.PublicKey(),
 		SigAlgo:        crypto.ECDSA_P256,
 		HashAlgo:       crypto.SHA3_256,
@@ -293,8 +293,8 @@ func (g *Transactions) New() *flow.Transaction {
 	// sign payload with proposal key
 	err := tx.SignPayload(
 		tx.ProposalKey.Address,
-		tx.ProposalKey.KeyID,
-		MockSigner([]byte{uint8(tx.ProposalKey.KeyID)}),
+		tx.ProposalKey.KeyIndex,
+		MockSigner([]byte{uint8(tx.ProposalKey.KeyIndex)}),
 	)
 	if err != nil {
 		panic(err)
@@ -330,7 +330,7 @@ func (g *Transactions) NewUnsigned() *flow.Transaction {
 		SetScript(GreetingScript).
 		SetReferenceBlockID(blockID).
 		SetGasLimit(42).
-		SetProposalKey(accountA.Address, proposalKey.ID, proposalKey.SequenceNumber).
+		SetProposalKey(accountA.Address, proposalKey.Index, proposalKey.SequenceNumber).
 		AddAuthorizer(accountA.Address).
 		SetPayer(accountB.Address)
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -38,11 +38,11 @@ func ExampleTransaction() {
 	// Mock user accounts
 
 	adrianLaptopKey := &flow.AccountKey{
-		ID:             3,
+		Index:          3,
 		SequenceNumber: 42,
 	}
 
-	adrianPhoneKey := &flow.AccountKey{ID: 2}
+	adrianPhoneKey := &flow.AccountKey{Index: 2}
 	addressA := addresses.New()
 
 	adrian := flow.Account{
@@ -53,7 +53,7 @@ func ExampleTransaction() {
 		},
 	}
 
-	blaineHardwareKey := &flow.AccountKey{ID: 7}
+	blaineHardwareKey := &flow.AccountKey{Index: 7}
 	addressB := addresses.New()
 
 	blaine := flow.Account{
@@ -69,7 +69,7 @@ func ExampleTransaction() {
 		SetScript([]byte(`transaction { execute { log("Hello, World!") } }`)).
 		SetReferenceBlockID(flow.Identifier{0x01, 0x02}).
 		SetGasLimit(42).
-		SetProposalKey(adrian.Address, adrianLaptopKey.ID, adrianLaptopKey.SequenceNumber).
+		SetProposalKey(adrian.Address, adrianLaptopKey.Index, adrianLaptopKey.SequenceNumber).
 		SetPayer(blaine.Address).
 		AddAuthorizer(adrian.Address)
 
@@ -77,17 +77,17 @@ func ExampleTransaction() {
 
 	// Signing
 
-	err := tx.SignPayload(adrian.Address, adrianLaptopKey.ID, test.MockSigner([]byte{1}))
+	err := tx.SignPayload(adrian.Address, adrianLaptopKey.Index, test.MockSigner([]byte{1}))
 	if err != nil {
 		panic(err)
 	}
 
-	err = tx.SignPayload(adrian.Address, adrianPhoneKey.ID, test.MockSigner([]byte{2}))
+	err = tx.SignPayload(adrian.Address, adrianPhoneKey.Index, test.MockSigner([]byte{2}))
 	if err != nil {
 		panic(err)
 	}
 
-	err = tx.SignEnvelope(blaine.Address, blaineHardwareKey.ID, test.MockSigner([]byte{3}))
+	err = tx.SignEnvelope(blaine.Address, blaineHardwareKey.Index, test.MockSigner([]byte{3}))
 	if err != nil {
 		panic(err)
 	}
@@ -95,9 +95,9 @@ func ExampleTransaction() {
 	fmt.Println("Payload signatures:")
 	for _, sig := range tx.PayloadSignatures {
 		fmt.Printf(
-			"Address: %s, Key ID: %d, Signature: %x\n",
+			"Address: %s, Key Index: %d, Signature: %x\n",
 			sig.Address,
-			sig.KeyID,
+			sig.KeyIndex,
 			sig.Signature,
 		)
 	}
@@ -106,9 +106,9 @@ func ExampleTransaction() {
 	fmt.Println("Envelope signatures:")
 	for _, sig := range tx.EnvelopeSignatures {
 		fmt.Printf(
-			"Address: %s, Key ID: %d, Signature: %x\n",
+			"Address: %s, Key Index: %d, Signature: %x\n",
 			sig.Address,
-			sig.KeyID,
+			sig.KeyIndex,
 			sig.Signature,
 		)
 	}
@@ -120,11 +120,11 @@ func ExampleTransaction() {
 	// Transaction ID (before signing): 8c362dd8b7553d48284cecc94d2ab545d513b29f930555632390fff5ca9772ee
 	//
 	// Payload signatures:
-	// Address: f8d6e0586b0a20c7, Key ID: 2, Signature: 02
-	// Address: f8d6e0586b0a20c7, Key ID: 3, Signature: 01
+	// Address: f8d6e0586b0a20c7, Key Index: 2, Signature: 02
+	// Address: f8d6e0586b0a20c7, Key Index: 3, Signature: 01
 	//
 	// Envelope signatures:
-	// Address: ee82856bf20e2aa6, Key ID: 7, Signature: 03
+	// Address: ee82856bf20e2aa6, Key Index: 7, Signature: 03
 	//
 	// Transaction ID (after signing): d1a2c58aebfce1050a32edf3568ec3b69cb8637ae090b5f7444ca6b2a8de8f8b
 }
@@ -248,14 +248,14 @@ func TestTransaction_SetGasLimit(t *testing.T) {
 
 func TestTransaction_SetProposalKey(t *testing.T) {
 	address := flow.ServiceAddress(flow.Mainnet)
-	keyID := 7
+	keyIndex := 7
 	var sequenceNumber uint64 = 42
 
 	tx := flow.NewTransaction().
-		SetProposalKey(address, keyID, sequenceNumber)
+		SetProposalKey(address, keyIndex, sequenceNumber)
 
 	assert.Equal(t, address, tx.ProposalKey.Address)
-	assert.Equal(t, keyID, tx.ProposalKey.KeyID)
+	assert.Equal(t, keyIndex, tx.ProposalKey.KeyIndex)
 	assert.Equal(t, sequenceNumber, tx.ProposalKey.SequenceNumber)
 }
 
@@ -308,7 +308,7 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		addressA := addresses.New()
 		addressB := addresses.New()
 
-		keyID := 7
+		keyIndex := 7
 		sig := []byte{42}
 
 		tx := flow.NewTransaction().
@@ -316,19 +316,19 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 			AddAuthorizer(addressB)
 
 		// add signatures in reverse order of declaration
-		tx.AddPayloadSignature(addressB, keyID, sig)
-		tx.AddPayloadSignature(addressA, keyID, sig)
+		tx.AddPayloadSignature(addressB, keyIndex, sig)
+		tx.AddPayloadSignature(addressA, keyIndex, sig)
 
 		require.Len(t, tx.PayloadSignatures, 2)
 
 		assert.Equal(t, 0, tx.PayloadSignatures[0].SignerIndex)
 		assert.Equal(t, addressA, tx.PayloadSignatures[0].Address)
-		assert.Equal(t, keyID, tx.PayloadSignatures[0].KeyID)
+		assert.Equal(t, keyIndex, tx.PayloadSignatures[0].KeyIndex)
 		assert.Equal(t, sig, tx.PayloadSignatures[0].Signature)
 
 		assert.Equal(t, 1, tx.PayloadSignatures[1].SignerIndex)
 		assert.Equal(t, addressB, tx.PayloadSignatures[1].Address)
-		assert.Equal(t, keyID, tx.PayloadSignatures[1].KeyID)
+		assert.Equal(t, keyIndex, tx.PayloadSignatures[1].KeyIndex)
 		assert.Equal(t, sig, tx.PayloadSignatures[1].Signature)
 	})
 
@@ -336,58 +336,58 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		addressA := addresses.New()
 		addressB := addresses.New()
 
-		keyID := 7
+		keyIndex := 7
 		sig := []byte{42}
 
 		tx := flow.NewTransaction().
-			SetProposalKey(addressA, keyID, 42).
+			SetProposalKey(addressA, keyIndex, 42).
 			AddAuthorizer(addressB).
 			AddAuthorizer(addressA)
 
 		// add signatures in reverse order of declaration
-		tx.AddPayloadSignature(addressB, keyID, sig)
-		tx.AddPayloadSignature(addressA, keyID, sig)
+		tx.AddPayloadSignature(addressB, keyIndex, sig)
+		tx.AddPayloadSignature(addressA, keyIndex, sig)
 
 		require.Len(t, tx.PayloadSignatures, 2)
 
 		assert.Equal(t, 0, tx.PayloadSignatures[0].SignerIndex)
 		assert.Equal(t, addressA, tx.PayloadSignatures[0].Address)
-		assert.Equal(t, keyID, tx.PayloadSignatures[0].KeyID)
+		assert.Equal(t, keyIndex, tx.PayloadSignatures[0].KeyIndex)
 		assert.Equal(t, sig, tx.PayloadSignatures[0].Signature)
 
 		assert.Equal(t, 1, tx.PayloadSignatures[1].SignerIndex)
 		assert.Equal(t, addressB, tx.PayloadSignatures[1].Address)
-		assert.Equal(t, keyID, tx.PayloadSignatures[1].KeyID)
+		assert.Equal(t, keyIndex, tx.PayloadSignatures[1].KeyIndex)
 		assert.Equal(t, sig, tx.PayloadSignatures[1].Signature)
 	})
 
 	t.Run("Multiple signatures", func(t *testing.T) {
 		address := addresses.New()
 
-		keyIDA := 7
+		keyIndexA := 7
 		sigA := []byte{42}
 
-		keyIDB := 8
+		keyIndexB := 8
 		sigB := []byte{43}
 
 		tx := flow.NewTransaction().
 			AddAuthorizer(address)
 
-		// add signatures in descending order by key ID
-		tx.AddPayloadSignature(address, keyIDB, sigB)
-		tx.AddPayloadSignature(address, keyIDA, sigA)
+		// add signatures in descending order by key index
+		tx.AddPayloadSignature(address, keyIndexB, sigB)
+		tx.AddPayloadSignature(address, keyIndexA, sigA)
 
 		require.Len(t, tx.PayloadSignatures, 2)
 
 		// signatures should be sorted in ascending order by key ID
 		assert.Equal(t, 0, tx.PayloadSignatures[0].SignerIndex)
 		assert.Equal(t, address, tx.PayloadSignatures[0].Address)
-		assert.Equal(t, keyIDA, tx.PayloadSignatures[0].KeyID)
+		assert.Equal(t, keyIndexA, tx.PayloadSignatures[0].KeyIndex)
 		assert.Equal(t, sigA, tx.PayloadSignatures[0].Signature)
 
 		assert.Equal(t, 0, tx.PayloadSignatures[1].SignerIndex)
 		assert.Equal(t, address, tx.PayloadSignatures[1].Address)
-		assert.Equal(t, keyIDB, tx.PayloadSignatures[1].KeyID)
+		assert.Equal(t, keyIndexB, tx.PayloadSignatures[1].KeyIndex)
 		assert.Equal(t, sigB, tx.PayloadSignatures[1].Signature)
 	})
 }
@@ -411,48 +411,48 @@ func TestTransaction_AddEnvelopeSignature(t *testing.T) {
 	t.Run("Valid signer", func(t *testing.T) {
 		address := addresses.New()
 
-		keyID := 7
+		keyIndex := 7
 		sig := []byte{42}
 
 		tx := flow.NewTransaction().
 			SetPayer(address)
 
-		tx.AddEnvelopeSignature(address, keyID, sig)
+		tx.AddEnvelopeSignature(address, keyIndex, sig)
 
 		require.Len(t, tx.EnvelopeSignatures, 1)
 
 		assert.Equal(t, 0, tx.EnvelopeSignatures[0].SignerIndex)
 		assert.Equal(t, address, tx.EnvelopeSignatures[0].Address)
-		assert.Equal(t, keyID, tx.EnvelopeSignatures[0].KeyID)
+		assert.Equal(t, keyIndex, tx.EnvelopeSignatures[0].KeyIndex)
 		assert.Equal(t, sig, tx.EnvelopeSignatures[0].Signature)
 	})
 
 	t.Run("Multiple signatures", func(t *testing.T) {
 		address := addresses.New()
 
-		keyIDA := 7
+		keyIndexA := 7
 		sigA := []byte{42}
 
-		keyIDB := 8
+		keyIndexB := 8
 		sigB := []byte{43}
 
 		tx := flow.NewTransaction().AddAuthorizer(address)
 
 		// add signatures in descending order by key ID
-		tx.AddEnvelopeSignature(address, keyIDB, sigB)
-		tx.AddEnvelopeSignature(address, keyIDA, sigA)
+		tx.AddEnvelopeSignature(address, keyIndexB, sigB)
+		tx.AddEnvelopeSignature(address, keyIndexA, sigA)
 
 		require.Len(t, tx.EnvelopeSignatures, 2)
 
 		// signatures should be sorted in ascending order by key ID
 		assert.Equal(t, 0, tx.EnvelopeSignatures[0].SignerIndex)
 		assert.Equal(t, address, tx.EnvelopeSignatures[0].Address)
-		assert.Equal(t, keyIDA, tx.EnvelopeSignatures[0].KeyID)
+		assert.Equal(t, keyIndexA, tx.EnvelopeSignatures[0].KeyIndex)
 		assert.Equal(t, sigA, tx.EnvelopeSignatures[0].Signature)
 
 		assert.Equal(t, 0, tx.EnvelopeSignatures[1].SignerIndex)
 		assert.Equal(t, address, tx.EnvelopeSignatures[1].Address)
-		assert.Equal(t, keyIDB, tx.EnvelopeSignatures[1].KeyID)
+		assert.Equal(t, keyIndexB, tx.EnvelopeSignatures[1].KeyIndex)
 		assert.Equal(t, sigB, tx.EnvelopeSignatures[1].Signature)
 	})
 }


### PR DESCRIPTION
This PR updates the definition for `flow.AccountKey` based on recent protocol changes.

- Add `Revoked` flag that indicates if a key has been revoked from an account
- Rename `AccountKey.ID` to `AccountKey.Index`