### PR TITLE
Updated sdk examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,7 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.10'
-      - run: go test ./...
+      - run: |
+          go clean -modcache
+          go mod tidy
+          go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,4 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.10'
-      - run: |
-          go clean -modcache
-          go mod tidy
-          go test ./...
+      - run: go test -v ./...

--- a/examples/add_account_key/main.go
+++ b/examples/add_account_key/main.go
@@ -52,10 +52,10 @@ func AddAccountKeyDemo() {
 
 	addKeyTx := templates.AddAccountKey(acctAddr, myAcctKey)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 
 	addKeyTx.SetProposalKey(acctAddr, acctKey.Index, acctKey.SequenceNumber)
-	addKeyTx.SetReferenceBlockID(referenceBlockId)
+	addKeyTx.SetReferenceBlockID(referenceBlockID)
 	addKeyTx.SetPayer(acctAddr)
 
 	// Sign the transaction with the new account.

--- a/examples/add_account_key/main.go
+++ b/examples/add_account_key/main.go
@@ -52,7 +52,10 @@ func AddAccountKeyDemo() {
 
 	addKeyTx := templates.AddAccountKey(acctAddr, myAcctKey)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+
 	addKeyTx.SetProposalKey(acctAddr, acctKey.Index, acctKey.SequenceNumber)
+	addKeyTx.SetReferenceBlockID(referenceBlockId)
 	addKeyTx.SetPayer(acctAddr)
 
 	// Sign the transaction with the new account.

--- a/examples/create_account/main.go
+++ b/examples/create_account/main.go
@@ -48,14 +48,14 @@ func CreateAccountDemo() {
 		SetHashAlgo(crypto.SHA3_256).
 		SetWeight(flow.AccountKeyWeightThreshold)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
 		serviceAcctKey.Index,
 		serviceAcctKey.SequenceNumber,
 	)
-	createAccountTx.SetReferenceBlockID(referenceBlockId)
+	createAccountTx.SetReferenceBlockID(referenceBlockID)
 	createAccountTx.SetPayer(serviceAcctAddr)
 
 	// Sign the transaction with the service account, which already exists

--- a/examples/create_account/main.go
+++ b/examples/create_account/main.go
@@ -48,12 +48,14 @@ func CreateAccountDemo() {
 		SetHashAlgo(crypto.SHA3_256).
 		SetWeight(flow.AccountKeyWeightThreshold)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
 		serviceAcctKey.Index,
 		serviceAcctKey.SequenceNumber,
 	)
+	createAccountTx.SetReferenceBlockID(referenceBlockId)
 	createAccountTx.SetPayer(serviceAcctAddr)
 
 	// Sign the transaction with the service account, which already exists

--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -54,14 +54,14 @@ func DeployContractDemo() {
 		SetWeight(flow.AccountKeyWeightThreshold)
 	mySigner := crypto.NewInMemorySigner(myPrivateKey, myAcctKey.HashAlgo)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
 		serviceAcctKey.Index,
 		serviceAcctKey.SequenceNumber,
 	)
-	createAccountTx.SetReferenceBlockID(referenceBlockId)
+	createAccountTx.SetReferenceBlockID(referenceBlockID)
 	createAccountTx.SetPayer(serviceAcctAddr)
 
 	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
@@ -93,7 +93,7 @@ func DeployContractDemo() {
 
 	deployContractTx.SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber)
 	// we can set the same reference block id. We shouldn't be to far away from it
-	deployContractTx.SetReferenceBlockID(referenceBlockId)
+	deployContractTx.SetReferenceBlockID(referenceBlockID)
 	deployContractTx.SetPayer(myAddress)
 
 	err = deployContractTx.SignEnvelope(
@@ -130,7 +130,7 @@ func DeployContractDemo() {
 		SetScript(createMinterScript).
 		SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber).
 		SetPayer(myAddress).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		AddAuthorizer(myAddress)
 
 	err = createMinterTx.SignEnvelope(myAddress, myAcctKey.Index, mySigner)
@@ -152,7 +152,7 @@ func DeployContractDemo() {
 		SetScript(mintScript).
 		SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber).
 		SetPayer(myAddress).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		AddAuthorizer(myAddress)
 
 	err = mintTx.SignEnvelope(myAddress, myAcctKey.Index, mySigner)

--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -54,12 +54,14 @@ func DeployContractDemo() {
 		SetWeight(flow.AccountKeyWeightThreshold)
 	mySigner := crypto.NewInMemorySigner(myPrivateKey, myAcctKey.HashAlgo)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
 		serviceAcctKey.Index,
 		serviceAcctKey.SequenceNumber,
 	)
+	createAccountTx.SetReferenceBlockID(referenceBlockId)
 	createAccountTx.SetPayer(serviceAcctAddr)
 
 	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
@@ -90,6 +92,8 @@ func DeployContractDemo() {
 	deployContractTx := templates.CreateAccount(nil, nftCode, myAddress)
 
 	deployContractTx.SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber)
+	// we can set the same reference block id. We shouldn't be to far away from it
+	deployContractTx.SetReferenceBlockID(referenceBlockId)
 	deployContractTx.SetPayer(myAddress)
 
 	err = deployContractTx.SignEnvelope(
@@ -126,6 +130,7 @@ func DeployContractDemo() {
 		SetScript(createMinterScript).
 		SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber).
 		SetPayer(myAddress).
+		SetReferenceBlockID(referenceBlockId).
 		AddAuthorizer(myAddress)
 
 	err = createMinterTx.SignEnvelope(myAddress, myAcctKey.Index, mySigner)
@@ -147,6 +152,7 @@ func DeployContractDemo() {
 		SetScript(mintScript).
 		SetProposalKey(myAddress, myAcctKey.Index, myAcctKey.SequenceNumber).
 		SetPayer(myAddress).
+		SetReferenceBlockID(referenceBlockId).
 		AddAuthorizer(myAddress)
 
 	err = mintTx.SignEnvelope(myAddress, myAcctKey.Index, mySigner)

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -142,9 +142,9 @@ func RandomAccount(flowClient *client.Client) (flow.Address, *flow.AccountKey, c
 }
 
 func GetReferenceBlockId(flowClient *client.Client) flow.Identifier {
-	blk, err := flowClient.GetLatestBlock(context.Background(), false)
+	block, err := flowClient.GetLatestBlock(context.Background(), true)
 	Handle(err)
-	return blk.ID
+	return block.ID
 }
 
 func DeployContract(flowClient *client.Client, code []byte) flow.Address {
@@ -156,12 +156,12 @@ func CreateAccount(flowClient *client.Client, publicKeys []*flow.AccountKey, cod
 	ctx := context.Background()
 
 	serviceAcctAddr, serviceAcctKey, serviceSigner := ServiceAccount(flowClient)
-	referenceBlockId := GetReferenceBlockId(flowClient)
+	referenceBlockID := GetReferenceBlockId(flowClient)
 
 	createAccountTx := templates.CreateAccount(publicKeys, code, serviceAcctAddr)
 	createAccountTx.
 		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(serviceAcctAddr)
 
 	err := createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -141,6 +141,12 @@ func RandomAccount(flowClient *client.Client) (flow.Address, *flow.AccountKey, c
 	return account.Address, account.Keys[0], signer
 }
 
+func GetReferenceBlockId(flowClient *client.Client) flow.Identifier {
+	blk, err := flowClient.GetLatestBlock(context.Background(), false)
+	Handle(err)
+	return blk.ID
+}
+
 func DeployContract(flowClient *client.Client, code []byte) flow.Address {
 	account := CreateAccount(flowClient, nil, code)
 	return account.Address
@@ -150,10 +156,12 @@ func CreateAccount(flowClient *client.Client, publicKeys []*flow.AccountKey, cod
 	ctx := context.Background()
 
 	serviceAcctAddr, serviceAcctKey, serviceSigner := ServiceAccount(flowClient)
+	referenceBlockId := GetReferenceBlockId(flowClient)
 
 	createAccountTx := templates.CreateAccount(publicKeys, code, serviceAcctAddr)
 	createAccountTx.
 		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(serviceAcctAddr)
 
 	err := createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)

--- a/examples/query_events/main.go
+++ b/examples/query_events/main.go
@@ -66,11 +66,11 @@ func QueryEventsDemo() {
 		}
 	`, contractAddr.Hex())
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	runScriptTx := flow.NewTransaction().
 		SetScript([]byte(script)).
 		SetPayer(acctAddr).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetProposalKey(acctAddr, acctKey.Index, acctKey.SequenceNumber)
 
 	err = runScriptTx.SignEnvelope(acctAddr, acctKey.Index, acctSigner)

--- a/examples/query_events/main.go
+++ b/examples/query_events/main.go
@@ -66,9 +66,11 @@ func QueryEventsDemo() {
 		}
 	`, contractAddr.Hex())
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	runScriptTx := flow.NewTransaction().
 		SetScript([]byte(script)).
 		SetPayer(acctAddr).
+		SetReferenceBlockID(referenceBlockId).
 		SetProposalKey(acctAddr, acctKey.Index, acctKey.SequenceNumber)
 
 	err = runScriptTx.SignEnvelope(acctAddr, acctKey.Index, acctSigner)

--- a/examples/transaction_arguments/main.go
+++ b/examples/transaction_arguments/main.go
@@ -45,11 +45,11 @@ func TransactionArgumentsDemo() {
 	message := test.GreetingGenerator().Random()
 	greeting := cadence.NewString(message)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript(test.GreetingScript).
 		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(serviceAcctAddr)
 
 	err = tx.AddArgument(greeting)

--- a/examples/transaction_arguments/main.go
+++ b/examples/transaction_arguments/main.go
@@ -45,9 +45,11 @@ func TransactionArgumentsDemo() {
 	message := test.GreetingGenerator().Random()
 	greeting := cadence.NewString(message)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript(test.GreetingScript).
 		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(serviceAcctAddr)
 
 	err = tx.AddArgument(greeting)

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -61,6 +61,7 @@ func MultiPartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1}, nil)
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3}, nil)
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
@@ -70,6 +71,7 @@ func MultiPartySingleSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -61,7 +61,7 @@ func MultiPartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1}, nil)
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3}, nil)
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
@@ -71,7 +71,7 @@ func MultiPartySingleSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/multi_party_multisig/main.go
+++ b/examples/transaction_signing/multi_party_multisig/main.go
@@ -79,7 +79,7 @@ func MultiPartyMultiSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2}, nil)
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3, key4}, nil)
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
@@ -89,7 +89,7 @@ func MultiPartyMultiSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/multi_party_multisig/main.go
+++ b/examples/transaction_signing/multi_party_multisig/main.go
@@ -79,6 +79,7 @@ func MultiPartyMultiSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2}, nil)
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3, key4}, nil)
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
@@ -88,6 +89,7 @@ func MultiPartyMultiSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/multi_party_two_authorizers/main.go
+++ b/examples/transaction_signing/multi_party_two_authorizers/main.go
@@ -62,7 +62,7 @@ func MultiPartySingleSignatureDemo() {
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1}, nil)
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3}, nil)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
 		transaction { 
@@ -73,7 +73,7 @@ func MultiPartySingleSignatureDemo() {
 		}`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address).
 		AddAuthorizer(account2.Address)

--- a/examples/transaction_signing/multi_party_two_authorizers/main.go
+++ b/examples/transaction_signing/multi_party_two_authorizers/main.go
@@ -62,6 +62,7 @@ func MultiPartySingleSignatureDemo() {
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1}, nil)
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3}, nil)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
 		transaction { 
@@ -72,6 +73,7 @@ func MultiPartySingleSignatureDemo() {
 		}`)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(account2.Address).
 		AddAuthorizer(account1.Address).
 		AddAuthorizer(account2.Address)

--- a/examples/transaction_signing/single_party/main.go
+++ b/examples/transaction_signing/single_party/main.go
@@ -52,6 +52,7 @@ func SinglePartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1}, nil)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
             transaction { 
@@ -60,6 +61,7 @@ func SinglePartySingleSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(account1.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/single_party/main.go
+++ b/examples/transaction_signing/single_party/main.go
@@ -52,7 +52,7 @@ func SinglePartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1}, nil)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
             transaction { 
@@ -61,7 +61,7 @@ func SinglePartySingleSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(account1.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/single_party_multisig/main.go
+++ b/examples/transaction_signing/single_party_multisig/main.go
@@ -61,6 +61,7 @@ func SinglePartyMultiSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2}, nil)
 
+	referenceBlockId := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
             transaction { 
@@ -69,6 +70,7 @@ func SinglePartyMultiSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
+		SetReferenceBlockID(referenceBlockId).
 		SetPayer(account1.Address).
 		AddAuthorizer(account1.Address)
 

--- a/examples/transaction_signing/single_party_multisig/main.go
+++ b/examples/transaction_signing/single_party_multisig/main.go
@@ -61,7 +61,7 @@ func SinglePartyMultiSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2}, nil)
 
-	referenceBlockId := examples.GetReferenceBlockId(flowClient)
+	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().
 		SetScript([]byte(`
             transaction { 
@@ -70,7 +70,7 @@ func SinglePartyMultiSignatureDemo() {
         `)).
 		SetGasLimit(100).
 		SetProposalKey(account1.Address, account1.Keys[0].Index, account1.Keys[0].SequenceNumber).
-		SetReferenceBlockID(referenceBlockId).
+		SetReferenceBlockID(referenceBlockID).
 		SetPayer(account1.Address).
 		AddAuthorizer(account1.Address)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6
 	github.com/ethereum/go-ethereum v1.9.9
 	github.com/golang/protobuf v1.4.2
-	github.com/onflow/cadence v0.8.0
+	github.com/onflow/cadence v0.9.0
 	github.com/onflow/flow/protobuf/go/flow v0.1.7
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6
 	github.com/ethereum/go-ethereum v1.9.9
 	github.com/golang/protobuf v1.4.2
-	github.com/onflow/cadence v0.9.0
+	github.com/onflow/cadence v0.9.1
 	github.com/onflow/flow/protobuf/go/flow v0.1.7
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/onflow/cadence v0.8.0 h1:7qMjZ3QJBdHZO+/HsxAJaLAXBJWVwT60Zw7t2PmJ/pY=
-github.com/onflow/cadence v0.8.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
+github.com/onflow/cadence v0.9.0 h1:370lLV1wJy8WRlWcbOlhykYIozuVd7aPIq95GjBcEPo=
+github.com/onflow/cadence v0.9.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/flow/protobuf/go/flow v0.1.7 h1:BaZVc1XWkI1vx/+qvdkXnKjsWk4UFRBAg7vvfQ/u5Pk=
 github.com/onflow/flow/protobuf/go/flow v0.1.7/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/onflow/cadence v0.9.0 h1:370lLV1wJy8WRlWcbOlhykYIozuVd7aPIq95GjBcEPo=
-github.com/onflow/cadence v0.9.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
+github.com/onflow/cadence v0.9.1 h1:ZgkR/e8P2vLDo9+QBVucfx8O/OKMiEwlUAzcJOIuqjc=
+github.com/onflow/cadence v0.9.1/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/flow/protobuf/go/flow v0.1.7 h1:BaZVc1XWkI1vx/+qvdkXnKjsWk4UFRBAg7vvfQ/u5Pk=
 github.com/onflow/flow/protobuf/go/flow v0.1.7/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

SDK examples didn't set ReferenceBlockId which has become mandatory. Emulator was updated to also require this: https://github.com/dapperlabs/flow-emulator/pull/103