### PR TITLE
Fix transaction size growing very quickly

### DIFF
--- a/examples/user_signature/main.go
+++ b/examples/user_signature/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/onflow/cadence"
@@ -40,9 +41,9 @@ var script = []byte(`
 import Crypto
 
 pub fun main(
-  rawPublicKeys: [[UInt8]],
+  rawPublicKeys: [String],
   weights: [UFix64],
-  signatures: [[UInt8]],
+  signatures: [String],
   toAddress: Address,
   fromAddress: Address,
   amount: UFix64,
@@ -53,7 +54,7 @@ pub fun main(
   for rawPublicKey in rawPublicKeys {
     keyList.add(
       Crypto.PublicKey(
-        publicKey: rawPublicKey,
+        publicKey: rawPublicKey.decodeHex(),
         signatureAlgorithm: Crypto.ECDSA_P256
       ),
       hashAlgorithm: Crypto.SHA3_256,
@@ -69,7 +70,7 @@ pub fun main(
     signatureSet.append(
       Crypto.KeyListSignature(
         keyIndex: j,
-        signature: signature
+        signature: signature.decodeHex()
       )
     )
     j = j + 1
@@ -126,8 +127,8 @@ func UserSignatureDemo() {
 	examples.Handle(err)
 
 	publicKeys := cadence.NewArray([]cadence.Value{
-		bytesToCadenceArray(publicKeyA.Encode()),
-		bytesToCadenceArray(publicKeyB.Encode()),
+		cadence.String(hex.EncodeToString(publicKeyA.Encode())),
+		cadence.String(hex.EncodeToString(publicKeyB.Encode())),
 	})
 
 	weightA, err := cadence.NewUFix64("0.5")
@@ -142,8 +143,8 @@ func UserSignatureDemo() {
 	})
 
 	signatures := cadence.NewArray([]cadence.Value{
-		bytesToCadenceArray(signatureA),
-		bytesToCadenceArray(signatureB),
+		cadence.String(hex.EncodeToString(signatureA)),
+		cadence.String(hex.EncodeToString(signatureB)),
 	})
 
 	value, err := flowClient.ExecuteScriptAtLatestBlock(

--- a/templates/accounts_test.go
+++ b/templates/accounts_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestCreateAccount(t *testing.T) {
-	// Converting transaction arguments to cadence values, can increase their size.
+	// Converting transaction arguments to Cadence values can increase their size.
 	// If this is not taken into account the transaction can quickly grow over the maximum transaction size limit.
 	t.Run("Transaction should not grow uncontrollably in size", func(t *testing.T) {
 		contractLen := 1000

--- a/templates/accounts_test.go
+++ b/templates/accounts_test.go
@@ -1,0 +1,53 @@
+/*
+ * Flow Go SDK
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package templates_test
+
+import (
+	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/templates"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCreateAccount(t *testing.T) {
+	// Converting transaction arguments to cadence values, can increase their size.
+	// If this is not taken into account the transaction can quickly grow over the maximum transaction size limit.
+	t.Run("Transaction should not grow uncontrollably in size", func(t *testing.T) {
+		contractLen := 1000
+		contractCode := make([]byte, contractLen)
+
+		tx := templates.CreateAccount(
+			[]*flow.AccountKey{},
+			[]templates.Contract{{
+				Name:   "contract",
+				Source: string(contractCode),
+			}},
+			flow.HexToAddress("01"))
+
+		txSize := len(tx.Script)
+		argumentsSize := 0
+		for _, argument := range tx.Arguments {
+			argumentsSize += len(argument)
+		}
+		require.Less(t, txSize, 1000, "The create account script should not grow over 1kB.")
+		require.Less(t, argumentsSize, contractLen*2+500,
+			"The create account argument size should not grow over "+
+				"2 times the contract code (converted to hex) + 500 bytes of extra data.")
+	})
+}


### PR DESCRIPTION
ref: https://github.com/dapperlabs/flow-go/issues/5056

## Description

Using `[Uint8]` parameter type to pass contract code to a transaction was causing the transaction size to grow with 30 bytes per byte of contract code. 

This was because converting a byte array to a cadence Uint array wrapped every byte with a lot extra type data.

I circumvented this by passing the code to the transaction as a hex encoded string instead of a `[Uint8]`. Doing it this way every byte of contract code increases the transaction size by only 2 bytes (because of the hex encoding).

A possible future expansion would be to use base64 encoding which would have a ratio of 1.3. Or even better than that, some sort of compression.


This was tested with this emulator version https://github.com/onflow/flow-emulator/tree/bastian/update-sdk-v0.12.0
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
