### PR TITLE
Add transaction decoding

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -120,3 +120,11 @@ func mustRLPEncode(v interface{}) []byte {
 	}
 	return b
 }
+
+func mustRLPDecode(b []byte, v interface{}) {
+	err := rlpDecode(b, v)
+	if err != nil {
+		panic(err)
+	}
+	return
+}

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,12 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OneOfOne/xxhash v1.2.5 h1:zl/OfRA6nftbBK9qTohYBJ5xvw6C/oNKizR7cZGl3cI=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/VictoriaMetrics/fastcache v1.5.3 h1:2odJnXLbFZcoV9KYtQ+7TH1UOq3dn3AssMgieaezkR4=
 github.com/VictoriaMetrics/fastcache v1.5.3/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847 h1:rtI0fD4oG/8eVokGVPYJEW1F88p1ZNgXiEIs9thEE4A=
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6 h1:Eey/GGQ/E5Xp1P2Lyx1qj007hLZfbi0+CoVeJruGCtI=
@@ -86,6 +88,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV0VO6mhG2V7jA9vbcGcnYF/Ay9NjZrY=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -106,6 +109,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
@@ -260,7 +264,9 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
+github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570 h1:gIlAHnH1vJb5vwEjIp5kBj/eu99p/bl0Ay2goiPe5xE=
 github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570/go.mod h1:8OR4w3TdeIHIh1g6EMY5p0gVNOovcWC+1vpc7naMuAw=
+github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 h1:njlZPzLwU639dk2kqnCPPv+wNjq7Xb6EfUxe/oX0/NM=
 github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUWaI9xL8pRQCTXQgocU38Qw1g0Us7n5PxxTwTCYU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=

--- a/transaction.go
+++ b/transaction.go
@@ -410,8 +410,7 @@ func DecodeTransactionPayloadMessage(envelopeMessage []byte) (*Transaction, erro
 	for i, auth := range temp.Authorizers {
 		authorizers[i] = BytesToAddress(auth)
 	}
-	t := new(Transaction)
-	*t = Transaction{
+	t := &Transaction{
 		Script:           temp.Script,
 		Arguments:        temp.Arguments,
 		ReferenceBlockID: BytesToID(temp.ReferenceBlockID),
@@ -437,7 +436,6 @@ func DecodeTransactionPayloadMessage(envelopeMessage []byte) (*Transaction, erro
 //
 // This message is only signed by the payer account.
 func DecodeTransactionEnvelopeMessage(envelopeMessage []byte) (*Transaction, error) {
-	t := new(Transaction)
 	temp := envelopeCanonicalForm{}
 	mustRLPDecode(envelopeMessage, &temp)
 	authorizers := make([]Address, len(temp.Payload.Authorizers))
@@ -449,7 +447,7 @@ func DecodeTransactionEnvelopeMessage(envelopeMessage []byte) (*Transaction, err
 	for i, sig := range temp.PayloadSignatures {
 		payloadSignatures[i] = transactionSignatureFromCanonicalForm(sig)
 	}
-	*t = Transaction{
+	t := &Transaction{
 		Script:           temp.Payload.Script,
 		Arguments:        temp.Payload.Arguments,
 		ReferenceBlockID: BytesToID(temp.Payload.ReferenceBlockID),
@@ -479,7 +477,6 @@ func DecodeTransactionEnvelopeMessage(envelopeMessage []byte) (*Transaction, err
 
 // DecodeTransaction returns the signable message for the transaction.
 func DecodeTransaction(transactionMessage []byte) (*Transaction, error) {
-	t := new(Transaction)
 	temp := transactionCanonicalForm{}
 	mustRLPDecode(transactionMessage, &temp)
 	authorizers := make([]Address, len(temp.Payload.Authorizers))
@@ -487,7 +484,7 @@ func DecodeTransaction(transactionMessage []byte) (*Transaction, error) {
 		fmt.Println(auth)
 		authorizers[i] = BytesToAddress(auth)
 	}
-	*t = Transaction{
+	t := &Transaction{
 		Script:           temp.Payload.Script,
 		Arguments:        temp.Payload.Arguments,
 		ReferenceBlockID: BytesToID(temp.Payload.ReferenceBlockID),

--- a/transaction.go
+++ b/transaction.go
@@ -557,12 +557,11 @@ func (s TransactionSignature) canonicalForm() transactionSignatureCanonicalForm 
 	}
 }
 
-func transactionSignatureFromCanonicalForm(v interface{}) TransactionSignature {
-	temp := v.(transactionSignatureCanonicalForm)
+func transactionSignatureFromCanonicalForm(v transactionSignatureCanonicalForm) TransactionSignature {
 	return TransactionSignature{
-		SignerIndex: int(temp.SignerIndex),
-		KeyIndex:    int(temp.KeyIndex),
-		Signature:   temp.Signature,
+		SignerIndex: int(v.SignerIndex),
+		KeyIndex:    int(v.KeyIndex),
+		Signature:   v.Signature,
 	}
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -328,23 +328,25 @@ func (t *Transaction) PayloadMessage() []byte {
 	return mustRLPEncode(&temp)
 }
 
-func (t *Transaction) payloadCanonicalForm() interface{} {
+type payloadCanonicalForm struct {
+	Script                    []byte
+	Arguments                 [][]byte
+	ReferenceBlockID          []byte
+	GasLimit                  uint64
+	ProposalKeyAddress        []byte
+	ProposalKeyIndex          uint64
+	ProposalKeySequenceNumber uint64
+	Payer                     []byte
+	Authorizers               [][]byte
+}
+
+func (t *Transaction) payloadCanonicalForm() payloadCanonicalForm {
 	authorizers := make([][]byte, len(t.Authorizers))
 	for i, auth := range t.Authorizers {
 		authorizers[i] = auth.Bytes()
 	}
 
-	return struct {
-		Script                    []byte
-		Arguments                 [][]byte
-		ReferenceBlockID          []byte
-		GasLimit                  uint64
-		ProposalKeyAddress        []byte
-		ProposalKeyIndex          uint64
-		ProposalKeySequenceNumber uint64
-		Payer                     []byte
-		Authorizers               [][]byte
-	}{
+	return payloadCanonicalForm{
 		Script:                    t.Script,
 		Arguments:                 t.Arguments,
 		ReferenceBlockID:          t.ReferenceBlockID[:],
@@ -365,11 +367,13 @@ func (t *Transaction) EnvelopeMessage() []byte {
 	return mustRLPEncode(&temp)
 }
 
-func (t *Transaction) envelopeCanonicalForm() interface{} {
-	return struct {
-		Payload           interface{}
-		PayloadSignatures interface{}
-	}{
+type envelopeCanonicalForm struct {
+	Payload           payloadCanonicalForm
+	PayloadSignatures []transactionSignatureCanonicalForm
+}
+
+func (t *Transaction) envelopeCanonicalForm() envelopeCanonicalForm {
+	return envelopeCanonicalForm{
 		Payload:           t.payloadCanonicalForm(),
 		PayloadSignatures: signaturesList(t.PayloadSignatures).canonicalForm(),
 	}
@@ -378,7 +382,7 @@ func (t *Transaction) envelopeCanonicalForm() interface{} {
 // Encode serializes the full transaction data including the payload and all signatures.
 func (t *Transaction) Encode() []byte {
 	temp := struct {
-		Payload            interface{}
+		Payload            payloadCanonicalForm
 		PayloadSignatures  interface{}
 		EnvelopeSignatures interface{}
 	}{
@@ -388,6 +392,68 @@ func (t *Transaction) Encode() []byte {
 	}
 
 	return mustRLPEncode(&temp)
+}
+
+// DecodeFromPayloadMessage returns the signable message for the transaction envelope.
+//
+// This message is only signed by the payer account.
+func (t *Transaction) DecodeFromPayloadMessage(envelopeMessage []byte) {
+	temp := t.envelopeCanonicalForm()
+	mustRLPDecode(envelopeMessage, &temp)
+	authorizers := make([]Address, len(temp.Payload.Authorizers))
+	for i, auth := range temp.Payload.Authorizers {
+		authorizers[i] = BytesToAddress(auth)
+	}
+	t = new(Transaction)
+	*t = Transaction{
+		Script:           temp.Payload.Script,
+		Arguments:        temp.Payload.Arguments,
+		ReferenceBlockID: BytesToID(temp.Payload.ReferenceBlockID),
+		GasLimit:         temp.Payload.GasLimit,
+		ProposalKey: ProposalKey{
+			Address:        BytesToAddress(temp.Payload.ProposalKeyAddress),
+			KeyIndex:       int(temp.Payload.ProposalKeyIndex),
+			SequenceNumber: temp.Payload.ProposalKeySequenceNumber,
+		},
+		Payer:       BytesToAddress(temp.Payload.Payer),
+		Authorizers: authorizers,
+	}
+	return
+}
+
+// DecodeFromEnvelopeMessage returns the signable message for the transaction envelope.
+//
+// This message is only signed by the payer account.
+func (t *Transaction) DecodeFromEnvelopeMessage(envelopeMessage []byte) {
+	temp := t.envelopeCanonicalForm()
+	mustRLPDecode(envelopeMessage, &temp)
+	authorizers := make([]Address, len(temp.Payload.Authorizers))
+	for i, auth := range temp.Payload.Authorizers {
+		fmt.Println(auth)
+		authorizers[i] = BytesToAddress(auth)
+	}
+	payloadSignatures := make([]TransactionSignature, len(temp.PayloadSignatures))
+	for i, sig := range temp.PayloadSignatures {
+		payloadSignatures[i] = transactionSignatureFromCanonicalForm(sig)
+	}
+	if t == nil {
+		t = new(Transaction)
+	}
+	*t = Transaction{
+		Script:           temp.Payload.Script,
+		Arguments:        temp.Payload.Arguments,
+		ReferenceBlockID: BytesToID(temp.Payload.ReferenceBlockID),
+		GasLimit:         temp.Payload.GasLimit,
+		ProposalKey: ProposalKey{
+			Address:        BytesToAddress(temp.Payload.ProposalKeyAddress),
+			KeyIndex:       int(temp.Payload.ProposalKeyIndex),
+			SequenceNumber: temp.Payload.ProposalKeySequenceNumber,
+		},
+		Payer:             BytesToAddress(temp.Payload.Payer),
+		Authorizers:       authorizers,
+		PayloadSignatures: payloadSignatures,
+	}
+	return
 }
 
 // A ProposalKey is the key that specifies the proposal key and sequence number for a transaction.
@@ -405,15 +471,26 @@ type TransactionSignature struct {
 	Signature   []byte
 }
 
-func (s TransactionSignature) canonicalForm() interface{} {
-	return struct {
-		SignerIndex uint
-		KeyIndex    uint
-		Signature   []byte
-	}{
+type transactionSignatureCanonicalForm struct {
+	SignerIndex uint
+	KeyIndex    uint
+	Signature   []byte
+}
+
+func (s TransactionSignature) canonicalForm() transactionSignatureCanonicalForm {
+	return transactionSignatureCanonicalForm{
 		SignerIndex: uint(s.SignerIndex), // int is not RLP-serializable
 		KeyIndex:    uint(s.KeyIndex),    // int is not RLP-serializable
 		Signature:   s.Signature,
+	}
+}
+
+func transactionSignatureFromCanonicalForm(v interface{}) TransactionSignature {
+	temp := v.(transactionSignatureCanonicalForm)
+	return TransactionSignature{
+		SignerIndex: int(temp.SignerIndex),
+		KeyIndex:    int(temp.KeyIndex),
+		Signature:   temp.Signature,
 	}
 }
 
@@ -427,8 +504,8 @@ func compareSignatures(signatures []TransactionSignature) func(i, j int) bool {
 
 type signaturesList []TransactionSignature
 
-func (s signaturesList) canonicalForm() interface{} {
-	signatures := make([]interface{}, len(s))
+func (s signaturesList) canonicalForm() []transactionSignatureCanonicalForm {
+	signatures := make([]transactionSignatureCanonicalForm, len(s))
 
 	for i, signature := range s {
 		signatures[i] = signature.canonicalForm()

--- a/transaction.go
+++ b/transaction.go
@@ -483,11 +483,9 @@ func decodeTransaction(transactionMessage []byte) (*transactionCanonicalForm, er
 	}
 	// If first kind is not list, safe to assume this is actually just encoded payload, and decrypt as such
 	if kind != rlp.List {
-		fmt.Println("Decoding as payload")
 		s.Reset(bytes.NewReader(transactionMessage), 0)
 		txPayload := payloadCanonicalForm{}
 		err := s.Decode(&txPayload)
-		fmt.Println(txPayload)
 		if err != nil {
 			return nil, err
 		}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -613,7 +613,7 @@ func TestTransaction_RLPMessages(t *testing.T) {
 			// Check tx decoding
 			transactionBytes := tt.tx.Encode()
 			newTx, err := flow.DecodeTransaction(transactionBytes)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.tx, newTx)
 			assert.Equal(t, tt.tx.ID(), newTx.ID())
@@ -622,8 +622,8 @@ func TestTransaction_RLPMessages(t *testing.T) {
 			envelopeBytes, err := hex.DecodeString(envelope)
 			assert.NoError(t, err)
 
-			newTxFromEnvelope, err := flow.DecodeTransactionEnvelopeMessage(envelopeBytes)
-			assert.NoError(t, err)
+			newTxFromEnvelope, err := flow.DecodeTransaction(envelopeBytes)
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.tx, newTxFromEnvelope)
 			assert.Equal(t, tt.tx.ID(), newTxFromEnvelope.ID())
@@ -632,8 +632,8 @@ func TestTransaction_RLPMessages(t *testing.T) {
 			payloadBytes, err := hex.DecodeString(payload)
 			assert.NoError(t, err)
 
-			newTxFromPayload, err := flow.DecodeTransactionPayloadMessage(payloadBytes)
-			assert.NoError(t, err)
+			newTxFromPayload, err := flow.DecodeTransaction(payloadBytes)
+			require.NoError(t, err)
 
 			txPayload := copyTxPayload(tt.tx)
 			assert.Equal(t, txPayload, newTxFromPayload)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -510,8 +510,9 @@ func TestTransaction_AbleToReconstructTransaction(t *testing.T) {
 	})
 }
 
+var sig, _ = hex.DecodeString("f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162")
+
 func baseTx() *flow.Transaction {
-	sig, _ := hex.DecodeString("f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162")
 	return flow.NewTransaction().
 		SetScript([]byte(`transaction { execute { log("Hello, World!") } }`)).
 		SetReferenceBlockID(flow.HexToID("f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b")).
@@ -534,6 +535,12 @@ func copyTxPayload(tx *flow.Transaction) *flow.Transaction {
 	}
 }
 
+func copyTxEnvelope(tx *flow.Transaction) *flow.Transaction {
+	newTx := copyTxPayload(tx)
+	newTx.PayloadSignatures = tx.PayloadSignatures
+	return newTx
+}
+
 // NOTE: The following tests have identical cases in the
 // JavaScript SDK to ensure parity between implementations:
 // https://github.com/onflow/flow-js-sdk/blob/master/packages/encode/src/encode.test.js
@@ -547,6 +554,12 @@ func TestTransaction_RLPMessages(t *testing.T) {
 		{
 			name:     "Complete transaction",
 			tx:       baseTx(),
+			payload:  "f872b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207dc0a0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001",
+			envelope: "f899f872b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207dc0a0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001e4e38004a0f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162",
+		},
+		{
+			name:     "Complete transaction with envelope sig",
+			tx:       baseTx().AddEnvelopeSignature(flow.HexToAddress("01"), 4, sig),
 			payload:  "f872b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207dc0a0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001",
 			envelope: "f899f872b07472616e73616374696f6e207b2065786563757465207b206c6f67282248656c6c6f2c20576f726c64212229207d207dc0a0f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b2a880000000000000001040a880000000000000001c9880000000000000001e4e38004a0f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162",
 		},
@@ -607,6 +620,8 @@ func TestTransaction_RLPMessages(t *testing.T) {
 			payload := hex.EncodeToString(tt.tx.PayloadMessage())
 			envelope := hex.EncodeToString(tt.tx.EnvelopeMessage())
 
+			fmt.Println(envelope)
+
 			assert.Equal(t, tt.payload, payload)
 			assert.Equal(t, tt.envelope, envelope)
 
@@ -625,8 +640,9 @@ func TestTransaction_RLPMessages(t *testing.T) {
 			newTxFromEnvelope, err := flow.DecodeTransaction(envelopeBytes)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.tx, newTxFromEnvelope)
-			assert.Equal(t, tt.tx.ID(), newTxFromEnvelope.ID())
+			txEnvelope := copyTxEnvelope(tt.tx)
+			assert.Equal(t, txEnvelope, newTxFromEnvelope)
+			assert.Equal(t, txEnvelope.ID(), newTxFromEnvelope.ID())
 
 			// Check payload decoding
 			payloadBytes, err := hex.DecodeString(payload)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -597,6 +597,15 @@ func TestTransaction_RLPMessages(t *testing.T) {
 
 			assert.Equal(t, tt.payload, payload)
 			assert.Equal(t, tt.envelope, envelope)
+
+			// payloadBytes, err := hex.DecodeString(payload)
+			// assert.NoError(t, err)
+			envelopeBytes, err := hex.DecodeString(envelope)
+			assert.NoError(t, err)
+
+			newTx := &flow.Transaction{}
+			newTx.DecodeFromEnvelopeMessage(envelopeBytes)
+			assert.Equal(t, tt.tx, newTx)
 		})
 	}
 }


### PR DESCRIPTION
Closes: #115

## Description

Adds RLP decode functionality for transactions

Two main considerations here:
- Is this how we want to handle the canonical forms? I've pulled them out as private structs, but not sure if this is the desired implementation
- Why does the transaction signature have address, but not pass it along? This causes all of my envelope decode tests to fail

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
