### PR TITLE
Add GetAccountAtBlockHeight

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -335,6 +335,31 @@ func (c *Client) GetAccountAtLatestBlock(
 	return &account, nil
 }
 
+// GetAccountAtBlockHeight gets an account by address at the given block height
+func (c *Client) GetAccountAtBlockHeight(
+	ctx context.Context,
+	address flow.Address,
+	blockHeight uint64,
+	opts ...grpc.CallOption,
+) (*flow.Account, error) {
+	req := &access.GetAccountAtBlockHeightRequest{
+		Address:     address.Bytes(),
+		BlockHeight: blockHeight,
+	}
+
+	res, err := c.rpcClient.GetAccountAtBlockHeight(ctx, req, opts...)
+	if err != nil {
+		return nil, newRPCError(err)
+	}
+
+	account, err := convert.MessageToAccount(res.GetAccount())
+	if err != nil {
+		return nil, newMessageToEntityError(entityAccount, err)
+	}
+
+	return &account, nil
+}
+
 // ExecuteScriptAtLatestBlock executes a read-only Cadence script against the latest sealed execution state.
 func (c *Client) ExecuteScriptAtLatestBlock(
 	ctx context.Context,


### PR DESCRIPTION
Closes: #

## Description

Adds the GetAccountAtBlockHeight client function, corresponding to: https://github.com/onflow/flow/blob/master/protobuf/flow/access/access.proto#L62 rpc

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
