### PR TITLE
Fix the decoding of Flow type IDs by importing Cadence's type ID decoder

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,0 +1,26 @@
+/*
+ * Flow Go SDK
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flow
+
+import (
+	// NOTE: always import Cadence's stdlib package,
+	// as it registers the type ID decoder for the Flow types,
+	// e.g. `flow.AccountCreated`
+	_ "github.com/onflow/cadence/runtime/stdlib"
+)

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,36 @@
+/*
+ * Flow Go SDK
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flow_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go-sdk"
+)
+
+func TestDecodeFlowTypeID(t *testing.T) {
+	location, qualifiedIdentifier, err := common.DecodeTypeID(flow.EventAccountCreated)
+	require.NoError(t, err)
+	assert.Equal(t, common.LocationID("flow"), location.ID())
+	assert.Equal(t, "AccountCreated", qualifiedIdentifier)
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,7 +1,7 @@
 /*
  * Flow Go SDK
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/event.go
+++ b/event.go
@@ -27,7 +27,6 @@ import (
 // List of built-in account event types.
 const (
 	EventAccountCreated string = "flow.AccountCreated"
-	EventAccountUpdated string = "flow.AccountUpdated"
 )
 
 type Event struct {


### PR DESCRIPTION
Closes onflow/cadence#509

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
