### PR TITLE
Update examples to work with tx fees

### DIFF
--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -87,7 +87,7 @@ func DeployContractDemo() {
 
 	fmt.Println("My Address:", myAddress.Hex())
 
-	examples.FundAccount(flowClient, myAddress, 100.0)
+	examples.FundAccountInEmulator(flowClient, myAddress, 100.0)
 	serviceAcctKey.SequenceNumber++
 
 	// Deploy the Great NFT contract
@@ -131,7 +131,7 @@ func DeployContractDemo() {
 
 	fmt.Println("My Address:", nftAddress.Hex())
 
-	examples.FundAccount(flowClient, nftAddress, 100.0)
+	examples.FundAccountInEmulator(flowClient, nftAddress, 100.0)
 	serviceAcctKey.SequenceNumber++
 
 	// Next, instantiate the minter

--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -87,6 +87,9 @@ func DeployContractDemo() {
 
 	fmt.Println("My Address:", myAddress.Hex())
 
+	examples.FundAccount(flowClient, myAddress, 100.0)
+	serviceAcctKey.SequenceNumber++
+
 	// Deploy the Great NFT contract
 	nftCode := examples.ReadFile(GreatTokenContractFile)
 	deployContractTx := templates.CreateAccount(nil,
@@ -103,7 +106,6 @@ func DeployContractDemo() {
 	// we can set the same reference block id. We shouldn't be to far away from it
 	deployContractTx.SetReferenceBlockID(referenceBlockID)
 	deployContractTx.SetPayer(serviceAcctAddr)
-
 
 	err = deployContractTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
 	examples.Handle(err)
@@ -128,6 +130,9 @@ func DeployContractDemo() {
 	}
 
 	fmt.Println("My Address:", nftAddress.Hex())
+
+	examples.FundAccount(flowClient, nftAddress, 100.0)
+	serviceAcctKey.SequenceNumber++
 
 	// Next, instantiate the minter
 	createMinterScript := GenerateCreateMinterScript(nftAddress, 1, 2)

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -23,6 +23,9 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime/sema"
 	"io/ioutil"
 	"os"
 	"time"
@@ -36,8 +39,7 @@ import (
 const configPath = "./flow.json"
 
 var (
-	servicePrivateKeyHex     string
-	servicePrivateKeySigAlgo crypto.SignatureAlgorithm
+	conf config
 )
 
 type config struct {
@@ -49,6 +51,7 @@ type config struct {
 			HashAlgo   string `json:"hashAlgorithm"`
 		}
 	}
+	Contracts map[string]string `json:"contracts"`
 }
 
 // ReadFile reads a file from the file system.
@@ -79,16 +82,15 @@ func readConfig() config {
 }
 
 func init() {
-	conf := readConfig()
-	servicePrivateKeyHex = conf.Accounts.Service.PrivateKey
-	servicePrivateKeySigAlgo = crypto.StringToSignatureAlgorithm(conf.Accounts.Service.SigAlgo)
+	conf = readConfig()
 }
 
 func ServiceAccount(flowClient *client.Client) (flow.Address, *flow.AccountKey, crypto.Signer) {
-	privateKey, err := crypto.DecodePrivateKeyHex(servicePrivateKeySigAlgo, servicePrivateKeyHex)
+	sigAlgo := crypto.StringToSignatureAlgorithm(conf.Accounts.Service.SigAlgo)
+	privateKey, err := crypto.DecodePrivateKeyHex(sigAlgo, conf.Accounts.Service.PrivateKey)
 	Handle(err)
 
-	addr := flow.ServiceAddress(flow.Emulator)
+	addr := flow.HexToAddress(conf.Accounts.Service.Address)
 	acc, err := flowClient.GetAccount(context.Background(), addr)
 	Handle(err)
 
@@ -118,6 +120,7 @@ func RandomAccount(flowClient *client.Client) (flow.Address, *flow.AccountKey, c
 		SetWeight(flow.AccountKeyWeightThreshold)
 
 	account := CreateAccount(flowClient, []*flow.AccountKey{accountKey})
+	FundAccount(flowClient, account.Address,10.0)
 	signer := crypto.NewInMemorySigner(privateKey, accountKey.HashAlgo)
 	return account.Address, account.Keys[0], signer
 }
@@ -158,6 +161,67 @@ func CreateAccountWithContracts(flowClient *client.Client, publicKeys []*flow.Ac
 	Handle(err)
 
 	return account
+}
+
+func FundAccount(flowClient *client.Client, address flow.Address, amount float64) {
+	serviceAcctAddr, serviceAcctKey, serviceSigner := ServiceAccount(flowClient)
+
+	referenceBlockID := GetReferenceBlockId(flowClient)
+
+	fungibleTokenAddress := flow.HexToAddress(conf.Contracts["FungibleToken"])
+	flowTokenAddress := flow.HexToAddress(conf.Contracts["FlowToken"])
+
+	recipient := cadence.NewAddress(address)
+	uintAmount := uint64(amount * sema.Fix64Factor)
+	cadenceAmount := cadence.UFix64(uintAmount)
+
+	fundAccountTx := flow.NewTransaction().
+		SetScript([]byte(fmt.Sprintf(`
+			import FungibleToken from 0x%s
+			import FlowToken from 0x%s
+			
+			transaction(recipient: Address, amount: UFix64) {
+				let tokenAdmin: &FlowToken.Administrator
+				let tokenReceiver: &{FungibleToken.Receiver}
+			
+				prepare(signer: AuthAccount) {
+					self.tokenAdmin = signer
+						.borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)
+						?? panic("Signer is not the token admin")
+			
+					self.tokenReceiver = getAccount(recipient)
+						.getCapability(/public/flowTokenReceiver)
+						.borrow<&{FungibleToken.Receiver}>()
+						?? panic("Unable to borrow receiver reference")
+				}
+			
+				execute {
+					let minter <- self.tokenAdmin.createNewMinter(allowedAmount: amount)
+					let mintedVault <- minter.mintTokens(amount: amount)
+			
+					self.tokenReceiver.deposit(from: <-mintedVault)
+			
+					destroy minter
+				}
+			}
+			`, fungibleTokenAddress, flowTokenAddress))).
+		AddAuthorizer(serviceAcctAddr).
+		AddRawArgument(jsoncdc.MustEncode(recipient)).
+		AddRawArgument(jsoncdc.MustEncode(cadenceAmount))
+	fundAccountTx.
+		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
+		SetReferenceBlockID(referenceBlockID).
+		SetPayer(serviceAcctAddr)
+
+	err := fundAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
+	Handle(err)
+
+	ctx := context.Background()
+	err = flowClient.SendTransaction(ctx, *fundAccountTx)
+	Handle(err)
+
+	result := WaitForSeal(ctx, flowClient, fundAccountTx.ID())
+	Handle(result.Error)
 }
 
 func CreateAccount(flowClient *client.Client, publicKeys []*flow.AccountKey) *flow.Account {

--- a/examples/flow.json
+++ b/examples/flow.json
@@ -1,10 +1,17 @@
 {
-	"accounts": {
-		"service": {
-			"address": "e467b9dd11fa00df",
-			"privateKey": "68ee617d9bf67a4677af80aaca5a090fcda80ff2f4dbc340e0e36201fa1f1d8c",
-			"sigAlgorithm": "ECDSA_P256",
-			"hashAlgorithm": "SHA3_256"
-		}
-	}
+  "accounts": {
+    "service": {
+      "address": "f8d6e0586b0a20c7",
+      "privateKey": "68ee617d9bf67a4677af80aaca5a090fcda80ff2f4dbc340e0e36201fa1f1d8c",
+      "sigAlgorithm": "ECDSA_P256",
+      "hashAlgorithm": "SHA3_256"
+    }
+  },
+  "contracts": {
+    "FlowServiceAccount": "f8d6e0586b0a20c7",
+    "FlowFees": "e5a8b7f23e8b548f",
+    "FlowStorageFees": "f8d6e0586b0a20c7",
+    "FlowToken": "0ae53cb6e3f42a79",
+    "FungibleToken": "ee82856bf20e2aa6"
+  }
 }

--- a/examples/storage_usage/main.go
+++ b/examples/storage_usage/main.go
@@ -91,7 +91,25 @@ func StorageUsageDemo() {
 		return
 	}
 
-	fmt.Println("Storage limit reached")
+	fmt.Println("Storage limit reached.")
+
+	// Add some flow to increase storage capacity
+	examples.FundAccount(flowClient, demoAccount.Address, 1.0)
+
+	// try to save a very large resource again. This time it should work.
+	txId = sendSaveLargeResourceTransaction(
+		ctx,
+		flowClient,
+		serviceAcctAddr,
+		serviceAcctKey,
+		serviceSigner,
+		demoAccount,
+		keySigner,
+	)
+
+	result = examples.WaitForSeal(ctx, flowClient, txId)
+
+	examples.Handle(result.Error)
 }
 
 func sendSaveLargeResourceTransaction(

--- a/examples/storage_usage/main.go
+++ b/examples/storage_usage/main.go
@@ -94,7 +94,7 @@ func StorageUsageDemo() {
 	fmt.Println("Storage limit reached.")
 
 	// Add some flow to increase storage capacity
-	examples.FundAccount(flowClient, demoAccount.Address, 1.0)
+	examples.FundAccountInEmulator(flowClient, demoAccount.Address, 1.0)
 
 	// try to save a very large resource again. This time it should work.
 	txId = sendSaveLargeResourceTransaction(

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -61,6 +61,9 @@ func MultiPartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1})
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3})
+	// Add some flow for the transaction fees
+	examples.FundAccount(flowClient, account2.Address, 1.0)
+
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 
 	tx := flow.NewTransaction().

--- a/examples/transaction_signing/multi_party/main.go
+++ b/examples/transaction_signing/multi_party/main.go
@@ -62,7 +62,7 @@ func MultiPartySingleSignatureDemo() {
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1})
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3})
 	// Add some flow for the transaction fees
-	examples.FundAccount(flowClient, account2.Address, 1.0)
+	examples.FundAccountInEmulator(flowClient, account2.Address, 1.0)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 

--- a/examples/transaction_signing/multi_party_multisig/main.go
+++ b/examples/transaction_signing/multi_party_multisig/main.go
@@ -79,6 +79,9 @@ func MultiPartyMultiSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2})
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3, key4})
+	// Add some flow for the transaction fees
+	examples.FundAccountInEmulator(flowClient, account2.Address, 1.0)
+
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 
 	tx := flow.NewTransaction().

--- a/examples/transaction_signing/multi_party_two_authorizers/main.go
+++ b/examples/transaction_signing/multi_party_two_authorizers/main.go
@@ -61,6 +61,8 @@ func MultiPartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1})
 	account2 := examples.CreateAccount(flowClient, []*flow.AccountKey{key3})
+	// Add some flow for the transaction fees
+	examples.FundAccountInEmulator(flowClient, account2.Address, 1.0)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().

--- a/examples/transaction_signing/single_party/main.go
+++ b/examples/transaction_signing/single_party/main.go
@@ -52,7 +52,7 @@ func SinglePartySingleSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1})
 	// Add some flow for the transaction fees
-	examples.FundAccount(flowClient, account1.Address, 1.0)
+	examples.FundAccountInEmulator(flowClient, account1.Address, 1.0)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().

--- a/examples/transaction_signing/single_party/main.go
+++ b/examples/transaction_signing/single_party/main.go
@@ -51,6 +51,8 @@ func SinglePartySingleSignatureDemo() {
 	key1Signer := crypto.NewInMemorySigner(privateKey1, key1.HashAlgo)
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1})
+	// Add some flow for the transaction fees
+	examples.FundAccount(flowClient, account1.Address, 1.0)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().

--- a/examples/transaction_signing/single_party_multisig/main.go
+++ b/examples/transaction_signing/single_party_multisig/main.go
@@ -61,7 +61,7 @@ func SinglePartyMultiSignatureDemo() {
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2})
 	// Add some flow for the transaction fees
-	examples.FundAccount(flowClient, account1.Address, 1.0)
+	examples.FundAccountInEmulator(flowClient, account1.Address, 1.0)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().

--- a/examples/transaction_signing/single_party_multisig/main.go
+++ b/examples/transaction_signing/single_party_multisig/main.go
@@ -60,6 +60,8 @@ func SinglePartyMultiSignatureDemo() {
 	key2Signer := crypto.NewInMemorySigner(privateKey2, key2.HashAlgo)
 
 	account1 := examples.CreateAccount(flowClient, []*flow.AccountKey{key1, key2})
+	// Add some flow for the transaction fees
+	examples.FundAccount(flowClient, account1.Address, 1.0)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 	tx := flow.NewTransaction().


### PR DESCRIPTION
ref: https://github.com/dapperlabs/flow-internal/issues/1384

## Description

The goal was to change the examples to work with transaction fees turned on.

This is just a suggestion.

How it works is that I added a `fund account` to the examples, which adds some flow to an account. Adding that little bit of flow in the examples makes them work even if the transaction fees or on.

This works with this version of the emulator: https://github.com/onflow/flow-emulator/pull/28 and transaction fees turned on.

Some questions I have:
- is this a good approach?
- where should I put the mint tokens script?
- how do I put the default flow addresses in the json? (I know this kid of connects to https://github.com/onflow/flow-cli/issues/30)

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
