### PR TITLE
fix outdated info in docs/creating-accounts.mdx

### DIFF
--- a/docs/creating-accounts.mdx
+++ b/docs/creating-accounts.mdx
@@ -112,7 +112,7 @@ tx := templates.CreateAccount([]*flow.AccountKey{accountKey}, nil, creatorAddres
 tx.SetPayer(creatorAddress)
 tx.SetProposalKey(
   creatorAddress,
-  creatorAccountKey.ID,
+  creatorAccountKey.Index,
   creatorAccountKey.SequenceNumber,
 )
 
@@ -126,7 +126,7 @@ tx.SetReferenceBlockID(latestBlock.ID)
 
 // Sign and submit the transaction
 
-err = tx.SignEnvelope(creatorAddress, creatorAccountKey.ID, creatorSigner)
+err = tx.SignEnvelope(creatorAddress, creatorAccountKey.Index, creatorSigner)
 if err != nil {
   panic("failed to sign transaction envelope")
 }


### PR DESCRIPTION
The [rename commit](https://github.com/yihau/flow-go-sdk/commit/96796f0cabc1847d7879a5230ab55fd3cdd41ae8) seems not update the docs together. I update docs/creating-accounts.mdx to correspond to the current AccountKey struct in golang.

