### PR TITLE
Add Seals to BlockPayload

### DIFF
--- a/block.go
+++ b/block.go
@@ -42,5 +42,9 @@ type BlockPayload struct {
 	Seals                []*BlockSeal
 }
 
-// TODO: define block seal struct
-type BlockSeal struct{}
+type BlockSeal struct {
+	BlockID            Identifier
+	ExecutionReceiptID Identifier
+	// TODO: ExecutionReceiptSignatures
+	// TODO: ResultApprovalSignatures
+}

--- a/client/convert/protobuf_test.go
+++ b/client/convert/protobuf_test.go
@@ -149,6 +149,17 @@ func TestConvert_CollectionGuarantee(t *testing.T) {
 	assert.Equal(t, *cgA, cgB)
 }
 
+func TestConvert_BlockSeal(t *testing.T) {
+	bsA := test.BlockSealGenerator().New()
+
+	msg := convert.BlockSealToMessage(*bsA)
+
+	bsB, err := convert.MessageToBlockSeal(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, *bsA, bsB)
+}
+
 func TestConvert_CollectionGuarantees(t *testing.T) {
 	cgs := test.CollectionGuaranteeGenerator()
 
@@ -164,6 +175,23 @@ func TestConvert_CollectionGuarantees(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, cgsA, cgsB)
+}
+
+func TestConvert_BlockSeals(t *testing.T) {
+	bss := test.BlockSealGenerator()
+
+	bssA := []*flow.BlockSeal{
+		bss.New(),
+		bss.New(),
+		bss.New(),
+	}
+
+	msg := convert.BlockSealsToMessages(bssA)
+
+	bssB, err := convert.MessagesToBlockSeals(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, bssA, bssB)
 }
 
 func TestConvert_Event(t *testing.T) {

--- a/test/entities.go
+++ b/test/entities.go
@@ -131,8 +131,11 @@ func (g *Blocks) New() *flow.Block {
 		g.guarantees.New(),
 	}
 
+	seals := []*flow.BlockSeal{}
+
 	payload := flow.BlockPayload{
 		CollectionGuarantees: guarantees,
+		Seals:                seals,
 	}
 
 	return &flow.Block{
@@ -191,6 +194,10 @@ type CollectionGuarantees struct {
 	ids *Identifiers
 }
 
+type BlockSeals struct {
+	ids *Identifiers
+}
+
 func CollectionGuaranteeGenerator() *CollectionGuarantees {
 	return &CollectionGuarantees{
 		ids: IdentifierGenerator(),
@@ -200,6 +207,19 @@ func CollectionGuaranteeGenerator() *CollectionGuarantees {
 func (g *CollectionGuarantees) New() *flow.CollectionGuarantee {
 	return &flow.CollectionGuarantee{
 		CollectionID: g.ids.New(),
+	}
+}
+
+func BlockSealGenerator() *BlockSeals {
+	return &BlockSeals{
+		ids: IdentifierGenerator(),
+	}
+}
+
+func (g *BlockSeals) New() *flow.BlockSeal {
+	return &flow.BlockSeal{
+		BlockID:            g.ids.New(),
+		ExecutionReceiptID: g.ids.New(),
 	}
 }
 

--- a/test/entities.go
+++ b/test/entities.go
@@ -113,12 +113,14 @@ func (g *Addresses) New() flow.Address {
 type Blocks struct {
 	headers    *BlockHeaders
 	guarantees *CollectionGuarantees
+	seals      *BlockSeals
 }
 
 func BlockGenerator() *Blocks {
 	return &Blocks{
 		headers:    BlockHeaderGenerator(),
 		guarantees: CollectionGuaranteeGenerator(),
+		seals:      BlockSealGenerator(),
 	}
 }
 
@@ -131,7 +133,9 @@ func (g *Blocks) New() *flow.Block {
 		g.guarantees.New(),
 	}
 
-	seals := []*flow.BlockSeal{}
+	seals := []*flow.BlockSeal{
+		g.seals.New(),
+	}
 
 	payload := flow.BlockPayload{
 		CollectionGuarantees: guarantees,


### PR DESCRIPTION
Closes: #148

## Description

Implements the `Seals` property of `BlockPayload` using the technique used for `CollectionGuarantees` as a guide.

Some [context on Discord](https://discord.com/channels/613813861610684416/709804784089301002/810364494902591488).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels