### PR TITLE
remove 0x prefix from string if sent to HexToAddress

### DIFF
--- a/address.go
+++ b/address.go
@@ -130,7 +130,7 @@ func zeroAddress(chain ChainID) Address {
 
 // HexToAddress converts a hex string to an Address.
 func HexToAddress(h string) Address {
-	b, _ := hex.DecodeString(h)
+	b, _ := hex.DecodeString(strings.TrimPrefix("0x", h))
 	return BytesToAddress(b)
 }
 

--- a/address.go
+++ b/address.go
@@ -1,7 +1,7 @@
 /*
  * Flow Go SDK
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/address_test.go
+++ b/address_test.go
@@ -33,6 +33,13 @@ type addressWrapper struct {
 	Address Address
 }
 
+func TestHextOAddress(t *testing.T) {
+	address := "123"
+	withPrefix := "0x" + address
+	assert.Equal(t, HexToAddress(address), HexToAddress(withPrefix))
+
+}
+
 func TestAddressJSON(t *testing.T) {
 	addr := ServiceAddress(Mainnet)
 	data, err := json.Marshal(addressWrapper{Address: addr})

--- a/address_test.go
+++ b/address_test.go
@@ -37,7 +37,6 @@ func TestHexToAddress(t *testing.T) {
 	address := "123"
 	withPrefix := "0x" + address
 	assert.Equal(t, HexToAddress(address), HexToAddress(withPrefix))
-
 }
 
 func TestAddressJSON(t *testing.T) {

--- a/address_test.go
+++ b/address_test.go
@@ -1,7 +1,7 @@
 /*
  * Flow Go SDK
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/address_test.go
+++ b/address_test.go
@@ -33,7 +33,7 @@ type addressWrapper struct {
 	Address Address
 }
 
-func TestHextOAddress(t *testing.T) {
+func TestHexToAddress(t *testing.T) {
 	address := "123"
 	withPrefix := "0x" + address
 	assert.Equal(t, HexToAddress(address), HexToAddress(withPrefix))


### PR DESCRIPTION
Closes: #151 

## Description
Remove the 0x prefix if it exist from the string before parsing

