### PR TITLE
Fix incorrect transaction signature ordering

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -571,7 +571,12 @@ func compareSignatures(signatures []TransactionSignature) func(i, j int) bool {
 	return func(i, j int) bool {
 		sigA := signatures[i]
 		sigB := signatures[j]
-		return sigA.SignerIndex < sigB.SignerIndex && sigA.KeyIndex < sigB.KeyIndex
+
+		if sigA.SignerIndex == sigB.SignerIndex {
+			return sigA.KeyIndex < sigB.KeyIndex
+		}
+
+		return sigA.SignerIndex < sigB.SignerIndex
 	}
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -571,7 +571,7 @@ func compareSignatures(signatures []TransactionSignature) func(i, j int) bool {
 	return func(i, j int) bool {
 		sigA := signatures[i]
 		sigB := signatures[j]
-		return sigA.SignerIndex < sigB.SignerIndex || sigA.KeyIndex < sigB.KeyIndex
+		return sigA.SignerIndex < sigB.SignerIndex && sigA.KeyIndex < sigB.KeyIndex
 	}
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -510,6 +510,46 @@ func TestTransaction_AbleToReconstructTransaction(t *testing.T) {
 	})
 }
 
+func TestTransaction_SignatureOrdering(t *testing.T) {
+	tx := flow.NewTransaction()
+
+	addresses := test.AddressGenerator()
+
+	proposerAddress := addresses.New()
+	proposerKeyIndex := 8
+	proposerSequenceNumber := uint64(42)
+	proposerSignature := []byte{1, 2, 3}
+
+	authorizerAddress := addresses.New()
+	authorizerKeyIndex := 0
+	authorizerSignature := []byte{4, 5, 6}
+
+	payerAddress := addresses.New()
+	payerKeyIndex := 0
+	payerSignature := []byte{7, 8, 9}
+
+	tx.SetProposalKey(proposerAddress, proposerKeyIndex, proposerSequenceNumber)
+
+	tx.AddPayloadSignature(proposerAddress, proposerKeyIndex, proposerSignature)
+
+	tx.SetPayer(payerAddress)
+	tx.AddEnvelopeSignature(payerAddress, payerKeyIndex, payerSignature)
+
+	tx.AddAuthorizer(authorizerAddress)
+	tx.AddPayloadSignature(authorizerAddress, authorizerKeyIndex, authorizerSignature)
+
+	t.Log(tx.PayloadSignatures)
+	t.Log(tx.EnvelopeSignatures)
+
+	require.Len(t, tx.PayloadSignatures, 2)
+
+	signatureA := tx.PayloadSignatures[0]
+	signatureB := tx.PayloadSignatures[1]
+
+	assert.Equal(t, proposerAddress, signatureA.Address)
+	assert.Equal(t, authorizerAddress, signatureB.Address)
+}
+
 var sig, _ = hex.DecodeString("f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162")
 
 func baseTx() *flow.Transaction {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -319,6 +319,8 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		tx.AddPayloadSignature(addressB, keyIndex, sig)
 		tx.AddPayloadSignature(addressA, keyIndex, sig)
 
+		t.Log(tx.PayloadSignatures)
+
 		require.Len(t, tx.PayloadSignatures, 2)
 
 		assert.Equal(t, 0, tx.PayloadSignatures[0].SignerIndex)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -319,8 +319,6 @@ func TestTransaction_AddPayloadSignature(t *testing.T) {
 		tx.AddPayloadSignature(addressB, keyIndex, sig)
 		tx.AddPayloadSignature(addressA, keyIndex, sig)
 
-		t.Log(tx.PayloadSignatures)
-
 		require.Len(t, tx.PayloadSignatures, 2)
 
 		assert.Equal(t, 0, tx.PayloadSignatures[0].SignerIndex)
@@ -540,9 +538,6 @@ func TestTransaction_SignatureOrdering(t *testing.T) {
 	tx.AddAuthorizer(authorizerAddress)
 	tx.AddPayloadSignature(authorizerAddress, authorizerKeyIndex, authorizerSignature)
 
-	t.Log(tx.PayloadSignatures)
-	t.Log(tx.EnvelopeSignatures)
-
 	require.Len(t, tx.PayloadSignatures, 2)
 
 	signatureA := tx.PayloadSignatures[0]
@@ -661,8 +656,6 @@ func TestTransaction_RLPMessages(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			payload := hex.EncodeToString(tt.tx.PayloadMessage())
 			envelope := hex.EncodeToString(tt.tx.EnvelopeMessage())
-
-			fmt.Println(envelope)
 
 			assert.Equal(t, tt.payload, payload)
 			assert.Equal(t, tt.envelope, envelope)


### PR DESCRIPTION
Closes: #163 

## Description

The `compareSignatures` function was not sorting correctly on two values.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
