### PR TITLE
Adds contentType tags.

### DIFF
--- a/docs/building-transactions.mdx
+++ b/docs/building-transactions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Build a Transaction
 description: How to prepare a transaction with the Flow Go SDK
+contentType: HOWTO
 ---
 
 Flow, like most blockchains, allows anybody to submit a transaction that mutates

--- a/docs/creating-accounts.mdx
+++ b/docs/creating-accounts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Create an Account
 description: How to create a Flow account with the Flow Go SDK
+contentType: HOWTO
 ---
 
 <Callout type="info">

--- a/docs/generating-keys.mdx
+++ b/docs/generating-keys.mdx
@@ -1,5 +1,6 @@
 ---
 title: Generating Keys
+contentType: HOWTO
 ---
 
 Flow uses [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Flow GO SDK
 description: Packages for Go developers to build applications that interact with the Flow network
+contentType: INTRO
 ---
 
 ## Installing

--- a/docs/querying-accounts.mdx
+++ b/docs/querying-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Querying Accounts
+contentType: HOWTO
 ---
 
 You can query the state of an account with the `GetAccount` function:

--- a/docs/querying-blocks.mdx
+++ b/docs/querying-blocks.mdx
@@ -1,6 +1,7 @@
 ---
 title: Querying Blocks
 description: How to query blocks using the Flow Go SDK
+contentType: HOWTO
 ---
 
 You can use the `GetLatestBlock` method to fetch the latest sealed or unsealed block:

--- a/docs/querying-events.mdx
+++ b/docs/querying-events.mdx
@@ -1,6 +1,7 @@
 ---
 title: Querying Events
 description: How to query events using the Flow Go SDK
+contentType: HOWTO
 ---
 
 You can query events with the `GetEventsForHeightRange` function:

--- a/docs/querying-transactions.mdx
+++ b/docs/querying-transactions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Querying Transaction Results
 description: How to query transaction results using the Flow Go SDK
+contentType: HOWTO
 ---
 
 After you have submitted a transaction, you can query its status by ID:

--- a/docs/sending-transactions.mdx
+++ b/docs/sending-transactions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Send a Transaction
 description: How to send a transaction with the Flow Go SDK
+contentType: HOWTO
 ---
 
 After a transaction has been [constructed](../build-transaction) and

--- a/docs/signing-transactions.mdx
+++ b/docs/signing-transactions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Signing Transactions
 description: How to cryptographically sign transactions using the Go SDK
+contentType: HOWTO
 ---
 
 Below is a simple example of how to sign a transaction using a `crypto.PrivateKey`.

--- a/docs/transfer-flow.mdx
+++ b/docs/transfer-flow.mdx
@@ -1,6 +1,7 @@
 ---
 title: Transfer FLOW
 description: How to transfer FLOW using the Flow Go SDK
+contentType: HOWTO
 ---
 
 This is an example of how to construct a FLOW token transfer transaction


### PR DESCRIPTION
## Description

### Tagging all markdown with the content type.

Possible content types: 
`HOWTO` (Guide)
`TUT` (Tutorial)
`INTRO` (index /intro page)
`EXP` (Explainer)
`REF` (Reference)
`FAQ` (Answers)

* all `README` are considered `INTRO` and all `CHANGELOG`&`WARNING` are considered `REF`

As outlined here: https://www.notion.so/dapperlabs/Types-of-Docs-033e722018f34036811ff38dac03eded

PR also formats whitespace.