### PR TITLE
Fix PEM decoding issue for some KMS keys

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -247,46 +247,37 @@ func DecodePublicKeyHex(sigAlgo SignatureAlgorithm, s string) (PublicKey, error)
 	return DecodePublicKey(sigAlgo, b)
 }
 
-// It is possible in some cases where the resulting byte slice from the PEM
-// decoding of the X and Y points do not generate the right size byte slices
-// If we know there is an expected length for a specific signature algorithm,
-// we make sure to left pad it to the right length. This is a mapping of the
-// signature algorithms to the expected length of the byte slices representing
-// the X and Y points
-var expectedPointByteLength = map[SignatureAlgorithm]int{
-	crypto.ECDSAP256: 32,
-}
-
-// DecodePublicKeyHex decodes a PEM public key with the given signature algorithm.
+// DecodePublicKeyHex decodes a PEM ECDSA public key with the given curve.
 func DecodePublicKeyPEM(sigAlgo SignatureAlgorithm, s string) (PublicKey, error) {
-	block, _ := pem.Decode([]byte(s))
+	block, rest := pem.Decode([]byte(s))
+	if len(rest) > 0 {
+		return PublicKey{}, fmt.Errorf("crypto: failed to parse PEM string, all not bytes in PEM key were decoded: %s", string(rest))
+	}
 
+	// TODO: Replace with function that is compatible with secp256k1
 	publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
 		return PublicKey{}, fmt.Errorf("crypto: failed to parse PEM string: %w", err)
 	}
 
-	goPublicKey := publicKey.(*ecdsa.PublicKey)
+	goPublicKey, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return PublicKey{}, fmt.Errorf("only ECDSA public keys are supported")
+	}
 	xBytes := goPublicKey.X.Bytes()
 	yBytes := goPublicKey.Y.Bytes()
-	expectedLength := expectedPointByteLength[sigAlgo]
-	var rawPublicKey []byte
-	if expectedLength > 0 {
-		// If an expected length for the point byte slice sizes, make sure to
-		// pad up to the expected length
-		rawPublicKey = make([]byte, 0, 2*expectedLength)
-		rawPublicKey = appendWithLeftPad(rawPublicKey, xBytes, expectedLength)
-		rawPublicKey = appendWithLeftPad(rawPublicKey, yBytes, expectedLength)
-	} else {
-		// If no expected length is provided, simply append the two slices
-		// together
-		rawPublicKey = append(
-			xBytes,
-			yBytes...,
-		)
-	}
+	expectedLength := bitsToBytes(goPublicKey.Params().P.BitLen())
+	// If an expected length for the point byte slice sizes, make sure to
+	// pad up to the expected length
+	rawPublicKey := make([]byte, 0, 2*expectedLength)
+	rawPublicKey = appendWithLeftPad(rawPublicKey, xBytes, expectedLength)
+	rawPublicKey = appendWithLeftPad(rawPublicKey, yBytes, expectedLength)
 
 	return DecodePublicKey(sigAlgo, rawPublicKey)
+}
+
+func bitsToBytes(bits int) int {
+	return (bits + 7) >> 3
 }
 
 func appendWithLeftPad(dst, src []byte, length int) []byte {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -129,3 +129,13 @@ func makeSeed(l int) []byte {
 	}
 	return seed
 }
+
+const TestPEM = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECi6YPHhCRPZWg0sUeNAi7QdpH5E8
+hbOhaN5CWXjw0HQAZeXqjoswiWlVH0baBuwAPwFcdk5fG/KW60QvOYPExA==
+-----END PUBLIC KEY-----`
+
+func TestDecodePublicKeyPEM(t *testing.T) {
+	_, err := crypto.DecodePublicKeyPEM(crypto.ECDSA_P256, TestPEM)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Closes: N/A

## Description

Was running into a PEM decode issue when working with some KMS keys. Kept getting `cryptokms: failed to parse PEM public key: input has incorrect ECDSA_P256 key size`.

The cause of this is sometimes, when calling `.Bytes()` on the X and Y points after decoding the PEM key, the corresponding byte slices were not the full 32 bytes, which was expected by the next function (expecting ECDSA_P256 keys to have a raw key of length 64)

This adds left padding (since the bytes are returned big endian) up to the expected length for ECDSA_P256 only. Can add other known lengths as we start to use them more.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
