### PR TITLE
[Crypto] Simplify nested key structures

### DIFF
--- a/crypto/cloudkms/cloudkms.go
+++ b/crypto/cloudkms/cloudkms.go
@@ -113,14 +113,14 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 
 	result, err := c.client.GetPublicKey(ctx, request)
 	if err != nil {
-		return crypto.PublicKey{},
+		return nil,
 			crypto.UnknownHashAlgorithm,
 			fmt.Errorf("cloudkms: failed to fetch public key from KMS API: %v", err)
 	}
 
 	sigAlgo := parseSignatureAlgorithm(result.Algorithm)
 	if sigAlgo == crypto.UnknownSignatureAlgorithm {
-		return crypto.PublicKey{},
+		return nil,
 			crypto.UnknownHashAlgorithm,
 			fmt.Errorf(
 				"cloudkms: unsupported signature algorithm %s",
@@ -130,7 +130,7 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 
 	hashAlgo := parseHashAlgorithm(result.Algorithm)
 	if hashAlgo == crypto.UnknownHashAlgorithm {
-		return crypto.PublicKey{},
+		return nil,
 			crypto.UnknownHashAlgorithm,
 			fmt.Errorf(
 				"cloudkms: unsupported hash algorithm %s",
@@ -140,7 +140,7 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 
 	publicKey, err := crypto.DecodePublicKeyPEM(sigAlgo, result.Pem)
 	if err != nil {
-		return crypto.PublicKey{},
+		return nil,
 			crypto.UnknownHashAlgorithm,
 			fmt.Errorf("cryptokms: failed to parse PEM public key: %w", err)
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -93,19 +93,10 @@ func CompatibleAlgorithms(sigAlgo SignatureAlgorithm, hashAlgo HashAlgorithm) bo
 }
 
 // A PrivateKey is a cryptographic private key that can be used for in-memory signing.
-type PrivateKey struct {
-	crypto.PrivateKey
-}
-
-// PublicKey returns the public key for this private key.
-func (sk PrivateKey) PublicKey() PublicKey {
-	return PublicKey{PublicKey: sk.PrivateKey.PublicKey()}
-}
+type PrivateKey = crypto.PrivateKey
 
 // A PublicKey is a cryptographic public key that can be used to verify signatures.
-type PublicKey struct {
-	crypto.PublicKey
-}
+type PublicKey = crypto.PublicKey
 
 // A Signer is capable of generating cryptographic signatures.
 type Signer interface {
@@ -161,7 +152,7 @@ func keyGenerationKMACTag(sigAlgo SignatureAlgorithm) []byte {
 func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, error) {
 	// check the seed has minimum entropy
 	if len(seed) < MinSeedLength {
-		return PrivateKey{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"crypto: insufficient seed length %d, must be at least %d bytes for %s",
 			len(seed),
 			MinSeedLength,
@@ -177,7 +168,7 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 	case ECDSA_secp256k1:
 		seedLen = crypto.KeyGenSeedMinLenECDSASecp256k1
 	default:
-		return PrivateKey{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"crypto: Go SDK does not support key generation for %s algorithm",
 			sigAlgo,
 		)
@@ -187,7 +178,7 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 	customizer := []byte("")
 	hasher, err := hash.NewKMAC_128(generationTag, customizer, seedLen)
 	if err != nil {
-		return PrivateKey{}, err
+		return nil, err
 	}
 
 	hashedSeed := hasher.ComputeHash(seed)
@@ -195,53 +186,33 @@ func GeneratePrivateKey(sigAlgo SignatureAlgorithm, seed []byte) (PrivateKey, er
 	// generate the key
 	privKey, err := crypto.GeneratePrivateKey(sigAlgo, hashedSeed)
 	if err != nil {
-		return PrivateKey{}, err
+		return nil, err
 	}
 
-	return PrivateKey{
-		PrivateKey: privKey,
-	}, nil
+	return privKey, nil
 }
 
 // DecodePrivateKey decodes a raw byte encoded private key with the given signature algorithm.
-func DecodePrivateKey(sigAlgo SignatureAlgorithm, b []byte) (PrivateKey, error) {
-	privKey, err := crypto.DecodePrivateKey(sigAlgo, b)
-	if err != nil {
-		return PrivateKey{}, err
-	}
-
-	return PrivateKey{
-		PrivateKey: privKey,
-	}, nil
-}
+var DecodePrivateKey = crypto.DecodePrivateKey
 
 // DecodePrivateKeyHex decodes a raw hex encoded private key with the given signature algorithm.
 func DecodePrivateKeyHex(sigAlgo SignatureAlgorithm, s string) (PrivateKey, error) {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		return PrivateKey{}, err
+		return nil, err
 	}
 
 	return DecodePrivateKey(sigAlgo, b)
 }
 
 // DecodePublicKey decodes a raw byte encoded public key with the given signature algorithm.
-func DecodePublicKey(sigAlgo SignatureAlgorithm, b []byte) (PublicKey, error) {
-	pubKey, err := crypto.DecodePublicKey(sigAlgo, b)
-	if err != nil {
-		return PublicKey{}, err
-	}
-
-	return PublicKey{
-		PublicKey: pubKey,
-	}, nil
-}
+var DecodePublicKey = crypto.DecodePublicKey
 
 // DecodePublicKeyHex decodes a raw hex encoded public key with the given signature algorithm.
 func DecodePublicKeyHex(sigAlgo SignatureAlgorithm, s string) (PublicKey, error) {
 	b, err := hex.DecodeString(s)
 	if err != nil {
-		return PublicKey{}, err
+		return nil, err
 	}
 
 	return DecodePublicKey(sigAlgo, b)
@@ -251,18 +222,18 @@ func DecodePublicKeyHex(sigAlgo SignatureAlgorithm, s string) (PublicKey, error)
 func DecodePublicKeyPEM(sigAlgo SignatureAlgorithm, s string) (PublicKey, error) {
 	block, rest := pem.Decode([]byte(s))
 	if len(rest) > 0 {
-		return PublicKey{}, fmt.Errorf("crypto: failed to parse PEM string, all not bytes in PEM key were decoded: %s", string(rest))
+		return nil, fmt.Errorf("crypto: failed to parse PEM string, all not bytes in PEM key were decoded: %s", string(rest))
 	}
 
 	// TODO: Replace with function that is compatible with secp256k1
 	publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return PublicKey{}, fmt.Errorf("crypto: failed to parse PEM string: %w", err)
+		return nil, fmt.Errorf("crypto: failed to parse PEM string: %w", err)
 	}
 
 	goPublicKey, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return PublicKey{}, fmt.Errorf("only ECDSA public keys are supported")
+		return nil, fmt.Errorf("only ECDSA public keys are supported")
 	}
 	xBytes := goPublicKey.X.Bytes()
 	yBytes := goPublicKey.Y.Bytes()

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -55,32 +55,32 @@ func TestGeneratePrivateKey(t *testing.T) {
 			t.Run("Nil seed", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, nil)
 				assert.Error(t, err)
-				assert.Equal(t, crypto.PrivateKey{}, sk)
+				assert.Equal(t, nil, sk)
 			})
 
 			t.Run("Empty seed", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, emptySeed)
 				assert.Error(t, err)
-				assert.Equal(t, crypto.PrivateKey{}, sk)
+				assert.Equal(t, nil, sk)
 			})
 
 			t.Run("Seed length too short", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, shortSeed)
 				assert.Error(t, err)
-				assert.Equal(t, crypto.PrivateKey{}, sk)
+				assert.Equal(t, nil, sk)
 			})
 
 			t.Run("Seed length exactly equal", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, equalSeed)
 				require.NoError(t, err)
-				assert.NotEqual(t, crypto.PrivateKey{}, sk)
+				assert.NotEqual(t, nil, sk)
 				assert.Equal(t, sigAlgo, sk.Algorithm())
 			})
 
 			t.Run("Valid signature algorithm", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, longSeed)
 				require.NoError(t, err)
-				assert.NotEqual(t, crypto.PrivateKey{}, sk)
+				assert.NotEqual(t, nil, sk)
 				assert.Equal(t, sigAlgo, sk.Algorithm())
 			})
 
@@ -110,7 +110,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 			t.Run(sigAlgo.String(), func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, longSeed)
 				assert.Error(t, err)
-				assert.Equal(t, crypto.PrivateKey{}, sk)
+				assert.Equal(t, nil, sk)
 			})
 		}
 	})
@@ -118,7 +118,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 	t.Run("Invalid signature algorithm", func(t *testing.T) {
 		sk, err := crypto.GeneratePrivateKey(invalidAlgo, longSeed)
 		assert.Error(t, err)
-		assert.Equal(t, crypto.PrivateKey{}, sk)
+		assert.Equal(t, nil, sk)
 	})
 }
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -55,19 +55,19 @@ func TestGeneratePrivateKey(t *testing.T) {
 			t.Run("Nil seed", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, nil)
 				assert.Error(t, err)
-				assert.Equal(t, nil, sk)
+				assert.Nil(t, sk)
 			})
 
 			t.Run("Empty seed", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, emptySeed)
 				assert.Error(t, err)
-				assert.Equal(t, nil, sk)
+				assert.Nil(t, sk)
 			})
 
 			t.Run("Seed length too short", func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, shortSeed)
 				assert.Error(t, err)
-				assert.Equal(t, nil, sk)
+				assert.Nil(t, sk)
 			})
 
 			t.Run("Seed length exactly equal", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 			t.Run(sigAlgo.String(), func(t *testing.T) {
 				sk, err := crypto.GeneratePrivateKey(sigAlgo, longSeed)
 				assert.Error(t, err)
-				assert.Equal(t, nil, sk)
+				assert.Nil(t, sk)
 			})
 		}
 	})
@@ -118,7 +118,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 	t.Run("Invalid signature algorithm", func(t *testing.T) {
 		sk, err := crypto.GeneratePrivateKey(invalidAlgo, longSeed)
 		assert.Error(t, err)
-		assert.Equal(t, nil, sk)
+		assert.Nil(t, sk)
 	})
 }
 


### PR DESCRIPTION
This PR doesn't address any ticket.

- simplifies the private and public key structures by using the `flow-go/crypto` structures.
- cleans up redundant functions.

