### PR TITLE
[Crypto] DecodePublicKeyPEM supports ECDSA secp256k1 keys 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.65.0
+	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/ethereum/go-ethereum v1.9.9
 	github.com/golang/protobuf v1.4.2
 	github.com/onflow/cadence v0.14.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.65.0
-	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/ethereum/go-ethereum v1.9.9
 	github.com/golang/protobuf v1.4.2
 	github.com/onflow/cadence v0.14.2


### PR DESCRIPTION
Closes: #176

## Description

 - refactor `DecodePublicKeyPEM` to optimize an extra round of decoding and encoding.
 - add support for ECDSA keys for secp256k1.
 - improve the tests.

