### PR TITLE
Add support for Google KMS keys with secp256k1 algorithm

### DIFF
--- a/crypto/cloudkms/cloudkms.go
+++ b/crypto/cloudkms/cloudkms.go
@@ -72,10 +72,10 @@ func KeyFromResourceID(resourceID string) (Key, error) {
 		strings.ReplaceAll(resourceIDFormat, "/", " "), // format
 		&key.ProjectID, &key.LocationID, &key.KeyRingID, &key.KeyID, &key.KeyVersion, // arguments to fill
 	)
-
 	if err != nil {
 		return key, fmt.Errorf("cloudkms: failed to parse resource ID %s, scanf error: %w", resourceID, err)
 	}
+
 	if scanned != resourceIDArgumentCount {
 		return key, fmt.Errorf("cloudkms: failed to parse resource ID %s, found %d arguments but expected %d", resourceID, scanned, resourceIDArgumentCount)
 	}
@@ -149,15 +149,23 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 }
 
 func parseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.SignatureAlgorithm {
-	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
+	switch algo {
+	case kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256:
 		return crypto.ECDSA_P256
+	case kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED:
+		// TODO: update this once API supports ECDSA_secp256k1
+		return crypto.ECDSA_secp256k1
 	}
 
 	return crypto.UnknownSignatureAlgorithm
 }
 
 func parseHashAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.HashAlgorithm {
-	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
+	switch algo {
+	case kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256:
+		return crypto.SHA2_256
+	case kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED:
+		// TODO: update this once API supports ECDSA_secp256k1
 		return crypto.SHA2_256
 	}
 

--- a/crypto/cloudkms/cloudkms.go
+++ b/crypto/cloudkms/cloudkms.go
@@ -154,6 +154,7 @@ func parseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorit
 	}
 
 	// TODO: update this once Google KMS API supports ECDSA_secp256k1
+	// https://github.com/onflow/flow-go-sdk/issues/193
 	return crypto.ECDSA_secp256k1
 }
 
@@ -163,5 +164,6 @@ func parseHashAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) c
 	}
 
 	// TODO: update this once Google KMS API supports ECDSA_secp256k1
+	// https://github.com/onflow/flow-go-sdk/issues/193
 	return crypto.SHA2_256
 }

--- a/crypto/cloudkms/cloudkms.go
+++ b/crypto/cloudkms/cloudkms.go
@@ -149,25 +149,19 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 }
 
 func parseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.SignatureAlgorithm {
-	switch algo {
-	case kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256:
+	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
 		return crypto.ECDSA_P256
-	case kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED:
-		// TODO: update this once API supports ECDSA_secp256k1
-		return crypto.ECDSA_secp256k1
 	}
 
-	return crypto.UnknownSignatureAlgorithm
+	// TODO: update this once Google KMS API supports ECDSA_secp256k1
+	return crypto.ECDSA_secp256k1
 }
 
 func parseHashAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.HashAlgorithm {
-	switch algo {
-	case kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256:
-		return crypto.SHA2_256
-	case kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED:
-		// TODO: update this once API supports ECDSA_secp256k1
+	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
 		return crypto.SHA2_256
 	}
 
-	return crypto.UnknownHashAlgorithm
+	// TODO: update this once Google KMS API supports ECDSA_secp256k1
+	return crypto.SHA2_256
 }


### PR DESCRIPTION
## Description

The Google KMS gRPC API does not yet have first class support for the secp256k1 signature algorithm.

This PR implements a workaround that we should replace once the API is updated. It's not ideal, but it will be backwards compatible once Google rolls out proper support in the API.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
