### PR TITLE
Doc/fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ err = tx.SignEnvelope(account1.Address, key2.Index, key2Signer)
 
 ---
 
-#### [Multiple parties](https://github.com/onflow/flow/blob/master/docs/accounts-and-keys.md#multiple-parties)
+#### [Multiple parties](https://docs.onflow.org/flow-go-sdk/signing-transactions/#multiple-parties)
 
 - Proposer and authorizer are the same account (`0x01`).
 - Payer is a separate account (`0x02`).

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ if err != nil {
 ### How Signatures Work in Flow
 
 Flow introduces new concepts that allow for more flexibility when creating and signing transactions. 
-Before trying the examples below, we recommend that you read through the [transaction signature documentation](https://github.com/onflow/flow/blob/master/docs/accounts-and-keys.md#signing-a-transaction).
+Before trying the examples below, we recommend that you read through the [transaction signature documentation](https://docs.onflow.org/concepts/transaction-signing/).
 
 ---
 


### PR DESCRIPTION
## Description

In the readme, the reference to some transaction signing docs led to a github 404 - docs probably lived on github at some point, and then you moved them to your site. updated with the relevant docs on your site.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work. N/A
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
