### PR TITLE
Add non-zero default transaction gas limit

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -110,9 +110,14 @@ type transactionCanonicalForm struct {
 	EnvelopeSignatures []transactionSignatureCanonicalForm
 }
 
+// DefaultTransactionGasLimit should be high enough for small transactions
+const DefaultTransactionGasLimit = 1000
+
 // NewTransaction initializes and returns an empty transaction.
 func NewTransaction() *Transaction {
-	return &Transaction{}
+	return &Transaction{
+		GasLimit: DefaultTransactionGasLimit,
+	}
 }
 
 // ID returns the canonical SHA3-256 hash of this transaction.

--- a/transaction.go
+++ b/transaction.go
@@ -111,7 +111,7 @@ type transactionCanonicalForm struct {
 }
 
 // DefaultTransactionGasLimit should be high enough for small transactions
-const DefaultTransactionGasLimit = 1000
+const DefaultTransactionGasLimit = 9999
 
 // NewTransaction initializes and returns an empty transaction.
 func NewTransaction() *Transaction {


### PR DESCRIPTION
## Description

Due to https://github.com/onflow/flow-go/pull/1220 a gas limit of 0 is no longer a valid gas limit.

I changed the default gas limit (when you call `NewTransaction()` to 1000, which is enough for all of the examples.

Any comments on the default gas limit amount are very welcome. 

This relates to this emulator PR https://github.com/onflow/flow-emulator/pull/78.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
