### PR TITLE
correct Flow emulator link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The Flow Go SDK provides a set of packages for Go developers to build applications that interact with the Flow network.
 
-*Note: This SDK is also fully compatible with the [Flow Emulator](https://docs.onflow.org/devtools/emulator/) and can be used for local development.*
+*Note: This SDK is also fully compatible with the [Flow Emulator](https://docs.onflow.org/emulator/) and can be used for local development.*
 
 ## [English](#) | [Chinese](/README_zh_CN.md)
 


### PR DESCRIPTION

## Description
This change fixes a dead link in the README file

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
