### PR TITLE
correct key weight document to be in the range of [1, 1000]

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Before trying the examples below, we recommend that you read through the [transa
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
+| `0x01`    | 1      | 1000   |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -255,12 +255,12 @@ err := tx.SignEnvelope(account1.Address, key1.Index, key1Signer)
 
 - Proposer, payer and authorizer are the same account (`0x01`).
 - Only the envelope must be signed.
-- Each key has weight 0.5, so two signatures are required.
+- Each key has weight 500, so two signatures are required.
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 0.5    |
-| `0x01`    | 2      | 0.5    |
+| `0x01`    | 1      | 500    |
+| `0x01`    | 2      | 500    |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -304,8 +304,8 @@ err = tx.SignEnvelope(account1.Address, key2.Index, key2Signer)
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
-| `0x02`    | 3      | 1.0    |
+| `0x01`    | 1      | 1000   |
+| `0x02`    | 3      | 1000   |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -351,8 +351,8 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
-| `0x02`    | 3      | 1.0    |
+| `0x01`    | 1      | 1000   |
+| `0x02`    | 3      | 1000   |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -403,10 +403,10 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 0.5    |
-| `0x01`    | 2      | 0.5    |
-| `0x02`    | 3      | 0.5    |
-| `0x02`    | 4      | 0.5    |
+| `0x01`    | 1      | 500    |
+| `0x01`    | 2      | 500    |
+| `0x02`    | 3      | 500    |
+| `0x02`    | 4      | 500    |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -214,7 +214,7 @@ Flow 引入了新的概念，允许在创建和签署事务时具有更大的灵
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
+| `0x01`    | 1      | 1000   |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -249,12 +249,12 @@ err := tx.SignEnvelope(account1.Address, key1.Index, key1Signer)
 
 - 只要交易必须签名
 
-- 每个密钥的权重为0.5，因此需要两个签名者。
+- 每个密钥的权重为500，因此需要两个签名者。
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 0.5    |
-| `0x01`    | 2      | 0.5    |
+| `0x01`    | 1      | 500    |
+| `0x01`    | 2      | 500    |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -303,8 +303,8 @@ err = tx.SignEnvelope(account1.Address, key2.Index, key2Signer)
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
-| `0x02`    | 3      | 1.0    |
+| `0x01`    | 1      | 1000   |
+| `0x02`    | 3      | 1000   |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -355,8 +355,8 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 1.0    |
-| `0x02`    | 3      | 1.0    |
+| `0x01`    | 1      | 1000   |
+| `0x02`    | 3      | 1000   |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))
@@ -412,10 +412,10 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 | Account   | Key ID | Weight |
 |-----------|--------|--------|
-| `0x01`    | 1      | 0.5    |
-| `0x01`    | 2      | 0.5    |
-| `0x02`    | 3      | 0.5    |
-| `0x02`    | 4      | 0.5    |
+| `0x01`    | 1      | 500    |
+| `0x01`    | 2      | 500    |
+| `0x02`    | 3      | 500    |
+| `0x02`    | 4      | 500    |
 
 ```go
 account1, _ := c.GetAccount(ctx, flow.HexToAddress("01"))

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -637,7 +637,7 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
+| `0x01`  | 1      | 1000   |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130" />](https://github.com/onflow/flow-go-sdk/tree/master/examples#single-party-single-signature)**
 ```go
@@ -670,12 +670,12 @@ err := tx.SignEnvelope(account1.Address, key1.Index, key1Signer)
 
 - Proposer, payer and authorizer are the same account (`0x01`).
 - Only the envelope must be signed.
-- Each key has weight 0.5, so two signatures are required.
+- Each key has weight 500, so two signatures are required.
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 0.5    |
-| `0x01`  | 2      | 0.5    |
+| `0x01`  | 1      | 500    |
+| `0x01`  | 2      | 500    |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130" />](https://github.com/onflow/flow-go-sdk/tree/master/examples#single-party-multiple-signatures)**
 ```go
@@ -718,8 +718,8 @@ err = tx.SignEnvelope(account1.Address, key2.Index, key2Signer)
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
-| `0x02`  | 3      | 1.0    |
+| `0x01`  | 1      | 1000   |
+| `0x02`  | 3      | 1000  |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130" />](https://github.com/onflow/flow-go-sdk/tree/master/examples#multiple-parties)**
 ```go
@@ -765,8 +765,8 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
-| `0x02`  | 3      | 1.0    |
+| `0x01`  | 1      | 1000   |
+| `0x02`  | 3      | 1000   |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130" />](https://github.com/onflow/flow-go-sdk/tree/master/examples#multiple-parties-two-authorizers)**
 ```go
@@ -816,10 +816,10 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 0.5    |
-| `0x01`  | 2      | 0.5    |
-| `0x02`  | 3      | 0.5    |
-| `0x02`  | 4      | 0.5    |
+| `0x01`  | 1      | 500    |
+| `0x01`  | 2      | 500    |
+| `0x02`  | 3      | 500    |
+| `0x02`  | 4      | 500    |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130" />](https://github.com/onflow/flow-go-sdk/tree/master/examples#multiple-parties-multiple-signatures)**
 ```go


### PR DESCRIPTION
## Description
Some documents are using 0.1 and 1.0 as key weight, which should be in the range of [1, 1000].
This change help with issue https://github.com/onflow/flow/issues/473

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
