### PR TITLE
Export cloudkms algorithm parsing functions and add method for accessing KeyManagementClient

### DIFF
--- a/crypto/cloudkms/cloudkms.go
+++ b/crypto/cloudkms/cloudkms.go
@@ -148,6 +148,12 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 	return publicKey, hashAlgo, nil
 }
 
+// KMSClient gives access to the KeyManagementClient,
+// e.g. for closing the connection to the Google KMS API
+func (c *Client) KMSClient() *kms.KeyManagementClient {
+	return c.client
+}
+
 func ParseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.SignatureAlgorithm {
 	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
 		return crypto.ECDSA_P256

--- a/crypto/cloudkms/cloudkms.go
+++ b/crypto/cloudkms/cloudkms.go
@@ -118,7 +118,7 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 			fmt.Errorf("cloudkms: failed to fetch public key from KMS API: %v", err)
 	}
 
-	sigAlgo := parseSignatureAlgorithm(result.Algorithm)
+	sigAlgo := ParseSignatureAlgorithm(result.Algorithm)
 	if sigAlgo == crypto.UnknownSignatureAlgorithm {
 		return nil,
 			crypto.UnknownHashAlgorithm,
@@ -128,7 +128,7 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 			)
 	}
 
-	hashAlgo := parseHashAlgorithm(result.Algorithm)
+	hashAlgo := ParseHashAlgorithm(result.Algorithm)
 	if hashAlgo == crypto.UnknownHashAlgorithm {
 		return nil,
 			crypto.UnknownHashAlgorithm,
@@ -148,7 +148,7 @@ func (c *Client) GetPublicKey(ctx context.Context, key Key) (crypto.PublicKey, c
 	return publicKey, hashAlgo, nil
 }
 
-func parseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.SignatureAlgorithm {
+func ParseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.SignatureAlgorithm {
 	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
 		return crypto.ECDSA_P256
 	}
@@ -158,7 +158,7 @@ func parseSignatureAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorit
 	return crypto.ECDSA_secp256k1
 }
 
-func parseHashAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.HashAlgorithm {
+func ParseHashAlgorithm(algo kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) crypto.HashAlgorithm {
 	if algo == kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256 {
 		return crypto.SHA2_256
 	}


### PR DESCRIPTION
Closes: #194
Closes: #201 

## Description

This PR makes the `cloudkms` algo parsing functions exported and adds a `KMSClient()` method for accessing the `KeyManagementClient` directly (e.g. for closing the client as requested in #194). Original PR #204, this PR contains the suggested modifications.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
