### PR TITLE
Add account proof helpers

### DIFF
--- a/account_proof.go
+++ b/account_proof.go
@@ -1,0 +1,64 @@
+package flow
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type canonicalAcctProofWithoutTag struct {
+	Addr      []byte
+	Timestamp uint64
+}
+
+type canonicalAcctProofWithTag struct {
+	DomainTag []byte
+	Addr      []byte
+	Timestamp uint64
+}
+
+// NewAccountProofMsg creates a new account proof message for singing. The appDomainTag is optional and can be left
+// empty. Note that the resulting byte slice does not contain the user domain tag.
+func NewAccountProofMsg(addr string, timestamp int64, appDomainTag string) ([]byte, error) {
+	decodedAddr, err := hex.DecodeString(addr)
+	if err != nil {
+		return nil, fmt.Errorf("error hex decoding address: %w", err)
+	}
+
+	var encodedMsg []byte
+
+	if appDomainTag != "" {
+		paddedTag, err := NewDomainTag(appDomainTag)
+		if err != nil {
+			return nil, fmt.Errorf("error encoding domain tag: %w", err)
+		}
+
+		encodedMsg, err = rlp.EncodeToBytes(&canonicalAcctProofWithTag{
+			Addr:      decodedAddr,
+			Timestamp: uint64(timestamp),
+			DomainTag: []byte(hex.EncodeToString(paddedTag[:])),
+		})
+	} else {
+		encodedMsg, err = rlp.EncodeToBytes(&canonicalAcctProofWithoutTag{
+			Addr:      decodedAddr,
+			Timestamp: uint64(timestamp),
+		})
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error encoding account proof message: %w", err)
+	}
+
+	return encodedMsg, nil
+}
+
+// NewDomainTag returns a new padded domain tag from the given string. This function returns an error if the domain
+// tag is too long.
+func NewDomainTag(tag string) (paddedTag [domainTagLength]byte, err error) {
+	if len(tag) > domainTagLength {
+		return paddedTag, fmt.Errorf("domain tag %s cannot be longer than %d characters", tag, domainTagLength)
+	}
+
+	return paddedDomainTag(tag), nil
+}

--- a/account_proof.go
+++ b/account_proof.go
@@ -25,13 +25,13 @@ import (
 )
 
 type canonicalAccountProofWithoutTag struct {
-	Addr      []byte
+	Address   []byte
 	Timestamp uint64
 }
 
 type canonicalAccountProofWithTag struct {
 	DomainTag []byte
-	Addr      []byte
+	Address   []byte
 	Timestamp uint64
 }
 
@@ -39,8 +39,8 @@ type canonicalAccountProofWithTag struct {
 // empty. Note that the resulting byte slice does not contain the user domain tag.
 func NewAccountProofMessage(address Address, timestamp int64, appDomainTag string) ([]byte, error) {
 	var (
-		encodedMsg []byte
-		err        error
+		encodedMessage []byte
+		err            error
 	)
 
 	if appDomainTag != "" {
@@ -49,14 +49,14 @@ func NewAccountProofMessage(address Address, timestamp int64, appDomainTag strin
 			return nil, fmt.Errorf("error encoding domain tag: %w", err)
 		}
 
-		encodedMsg, err = rlp.EncodeToBytes(&canonicalAccountProofWithTag{
+		encodedMessage, err = rlp.EncodeToBytes(&canonicalAccountProofWithTag{
 			DomainTag: paddedTag[:],
-			Addr:      address.Bytes(),
+			Address:   address.Bytes(),
 			Timestamp: uint64(timestamp),
 		})
 	} else {
-		encodedMsg, err = rlp.EncodeToBytes(&canonicalAccountProofWithoutTag{
-			Addr:      address.Bytes(),
+		encodedMessage, err = rlp.EncodeToBytes(&canonicalAccountProofWithoutTag{
+			Address:   address.Bytes(),
 			Timestamp: uint64(timestamp),
 		})
 	}
@@ -65,7 +65,7 @@ func NewAccountProofMessage(address Address, timestamp int64, appDomainTag strin
 		return nil, fmt.Errorf("error encoding account proof message: %w", err)
 	}
 
-	return encodedMsg, nil
+	return encodedMessage, nil
 }
 
 // NewDomainTag returns a new padded domain tag from the given string. This function returns an error if the domain

--- a/account_proof.go
+++ b/account_proof.go
@@ -1,32 +1,29 @@
 package flow
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-type canonicalAcctProofWithoutTag struct {
+type canonicalAccountProofWithoutTag struct {
 	Addr      []byte
 	Timestamp uint64
 }
 
-type canonicalAcctProofWithTag struct {
+type canonicalAccountProofWithTag struct {
 	DomainTag []byte
 	Addr      []byte
 	Timestamp uint64
 }
 
-// NewAccountProofMsg creates a new account proof message for singing. The appDomainTag is optional and can be left
+// NewAccountProofMessage creates a new account proof message for singing. The appDomainTag is optional and can be left
 // empty. Note that the resulting byte slice does not contain the user domain tag.
-func NewAccountProofMsg(addr string, timestamp int64, appDomainTag string) ([]byte, error) {
-	decodedAddr, err := hex.DecodeString(addr)
-	if err != nil {
-		return nil, fmt.Errorf("error hex decoding address: %w", err)
-	}
-
-	var encodedMsg []byte
+func NewAccountProofMessage(address Address, timestamp int64, appDomainTag string) ([]byte, error) {
+	var (
+		encodedMsg []byte
+		err        error
+	)
 
 	if appDomainTag != "" {
 		paddedTag, err := NewDomainTag(appDomainTag)
@@ -34,14 +31,14 @@ func NewAccountProofMsg(addr string, timestamp int64, appDomainTag string) ([]by
 			return nil, fmt.Errorf("error encoding domain tag: %w", err)
 		}
 
-		encodedMsg, err = rlp.EncodeToBytes(&canonicalAcctProofWithTag{
-			Addr:      decodedAddr,
+		encodedMsg, err = rlp.EncodeToBytes(&canonicalAccountProofWithTag{
+			DomainTag: paddedTag[:],
+			Addr:      address.Bytes(),
 			Timestamp: uint64(timestamp),
-			DomainTag: []byte(hex.EncodeToString(paddedTag[:])),
 		})
 	} else {
-		encodedMsg, err = rlp.EncodeToBytes(&canonicalAcctProofWithoutTag{
-			Addr:      decodedAddr,
+		encodedMsg, err = rlp.EncodeToBytes(&canonicalAccountProofWithoutTag{
+			Addr:      address.Bytes(),
 			Timestamp: uint64(timestamp),
 		})
 	}

--- a/account_proof.go
+++ b/account_proof.go
@@ -44,7 +44,7 @@ func NewAccountProofMessage(address Address, timestamp int64, appDomainTag strin
 	)
 
 	if appDomainTag != "" {
-		paddedTag, err := NewDomainTag(appDomainTag)
+		paddedTag, err := padDomainTag(appDomainTag)
 		if err != nil {
 			return nil, fmt.Errorf("error encoding domain tag: %w", err)
 		}
@@ -66,14 +66,4 @@ func NewAccountProofMessage(address Address, timestamp int64, appDomainTag strin
 	}
 
 	return encodedMessage, nil
-}
-
-// NewDomainTag returns a new padded domain tag from the given string. This function returns an error if the domain
-// tag is too long.
-func NewDomainTag(tag string) (paddedTag [domainTagLength]byte, err error) {
-	if len(tag) > domainTagLength {
-		return paddedTag, fmt.Errorf("domain tag %s cannot be longer than %d characters", tag, domainTagLength)
-	}
-
-	return paddedDomainTag(tag), nil
 }

--- a/account_proof_test.go
+++ b/account_proof_test.go
@@ -31,7 +31,6 @@ func TestNewAccountProofMsg(t *testing.T) {
 		timestamp      int64
 		appDomainTag   string
 		expectedResult string
-		expectedErr    error
 	}
 
 	for name, tc := range map[string]testCase{

--- a/account_proof_test.go
+++ b/account_proof_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewAccountProofMsg(t *testing.T) {
 	type testCase struct {
-		addr           string
+		addr           Address
 		timestamp      int64
 		appDomainTag   string
 		expectedResult string
@@ -18,20 +18,20 @@ func TestNewAccountProofMsg(t *testing.T) {
 
 	for name, tc := range map[string]testCase{
 		"with domain tag": {
-			addr:           "1234123412341234",
-			timestamp:      int64(1644259653161),
-			appDomainTag:   "AWESOME-APP-V0.0-user",
-			expectedResult: "f852b8403431353734353533346634643435326434313530353032643536333032653330326437353733363537323030303030303030303030303030303030303030303088123412341234123486017ed5833629",
+			addr:           HexToAddress("ABC123DEF456"),
+			timestamp:      int64(1632179933495),
+			appDomainTag:   "FLOW-JS-SDK",
+			expectedResult: "f1a0464c4f572d4a532d53444b000000000000000000000000000000000000000000880000abc123def45686017c05815137",
 		},
 		"without domain tag": {
-			addr:           "1234123412341234",
-			timestamp:      int64(1644259653161),
-			expectedResult: "d088123412341234123486017ed5833629",
+			addr:           HexToAddress("ABC123DEF456"),
+			timestamp:      int64(1632179933495),
+			expectedResult: "d0880000abc123def45686017c05815137",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			// Check the output of NewAccountProofMsg against a pre-generated message from the flow-js-sdk
-			msg, err := NewAccountProofMsg(tc.addr, tc.timestamp, tc.appDomainTag)
+			// Check the output of NewAccountProofMessage against a pre-generated message from the flow-js-sdk
+			msg, err := NewAccountProofMessage(tc.addr, tc.timestamp, tc.appDomainTag)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, hex.EncodeToString(msg))
 		})

--- a/account_proof_test.go
+++ b/account_proof_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestNewAccountProofMsg(t *testing.T) {
 	type testCase struct {
-		addr           Address
+		address        Address
 		timestamp      int64
 		appDomainTag   string
 		expectedResult string
@@ -36,20 +36,20 @@ func TestNewAccountProofMsg(t *testing.T) {
 
 	for name, tc := range map[string]testCase{
 		"with domain tag": {
-			addr:           HexToAddress("ABC123DEF456"),
+			address:        HexToAddress("ABC123DEF456"),
 			timestamp:      int64(1632179933495),
 			appDomainTag:   "FLOW-JS-SDK",
 			expectedResult: "f1a0464c4f572d4a532d53444b000000000000000000000000000000000000000000880000abc123def45686017c05815137",
 		},
 		"without domain tag": {
-			addr:           HexToAddress("ABC123DEF456"),
+			address:        HexToAddress("ABC123DEF456"),
 			timestamp:      int64(1632179933495),
 			expectedResult: "d0880000abc123def45686017c05815137",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			// Check the output of NewAccountProofMessage against a pre-generated message from the flow-js-sdk
-			msg, err := NewAccountProofMessage(tc.addr, tc.timestamp, tc.appDomainTag)
+			msg, err := NewAccountProofMessage(tc.address, tc.timestamp, tc.appDomainTag)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, hex.EncodeToString(msg))
 		})

--- a/account_proof_test.go
+++ b/account_proof_test.go
@@ -1,0 +1,39 @@
+package flow
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAccountProofMsg(t *testing.T) {
+	type testCase struct {
+		addr           string
+		timestamp      int64
+		appDomainTag   string
+		expectedResult string
+		expectedErr    error
+	}
+
+	for name, tc := range map[string]testCase{
+		"with domain tag": {
+			addr:           "1234123412341234",
+			timestamp:      int64(1644259653161),
+			appDomainTag:   "AWESOME-APP-V0.0-user",
+			expectedResult: "f852b8403431353734353533346634643435326434313530353032643536333032653330326437353733363537323030303030303030303030303030303030303030303088123412341234123486017ed5833629",
+		},
+		"without domain tag": {
+			addr:           "1234123412341234",
+			timestamp:      int64(1644259653161),
+			expectedResult: "d088123412341234123486017ed5833629",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Check the output of NewAccountProofMsg against a pre-generated message from the flow-js-sdk
+			msg, err := NewAccountProofMsg(tc.addr, tc.timestamp, tc.appDomainTag)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, hex.EncodeToString(msg))
+		})
+	}
+}

--- a/sign.go
+++ b/sign.go
@@ -37,15 +37,12 @@ var TransactionDomainTag = mustPadDomainTag("FLOW-V0.0-transaction")
 var UserDomainTag = mustPadDomainTag("FLOW-V0.0-user")
 
 func mustPadDomainTag(s string) [domainTagLength]byte {
-	var tag [domainTagLength]byte
-
-	if len(s) > domainTagLength {
-		panic(fmt.Sprintf("domain tag %s cannot be longer than %d characters", s, domainTagLength))
+	paddedTag, err := padDomainTag(s)
+	if err != nil {
+		panic(err)
 	}
 
-	copy(tag[:], s)
-
-	return tag
+	return paddedTag
 }
 
 // padDomainTag returns a new padded domain tag from the given string. This function returns an error if the domain
@@ -55,7 +52,9 @@ func padDomainTag(tag string) (paddedTag [domainTagLength]byte, err error) {
 		return paddedTag, fmt.Errorf("domain tag %s cannot be longer than %d characters", tag, domainTagLength)
 	}
 
-	return mustPadDomainTag(tag), nil
+	copy(paddedTag[:], tag)
+
+	return paddedTag, nil
 }
 
 // SignUserMessage signs a message in the user domain.

--- a/sign.go
+++ b/sign.go
@@ -29,14 +29,14 @@ const domainTagLength = 32
 // TransactionDomainTag is the prefix of all signed transaction payloads.
 //
 // A domain tag is encoded as UTF-8 bytes, right padded to a total length of 32 bytes.
-var TransactionDomainTag = paddedDomainTag("FLOW-V0.0-transaction")
+var TransactionDomainTag = mustPadDomainTag("FLOW-V0.0-transaction")
 
 // UserDomainTag is the prefix of all signed user space payloads.
 //
 // A domain tag is encoded as UTF-8 bytes, right padded to a total length of 32 bytes.
-var UserDomainTag = paddedDomainTag("FLOW-V0.0-user")
+var UserDomainTag = mustPadDomainTag("FLOW-V0.0-user")
 
-func paddedDomainTag(s string) [domainTagLength]byte {
+func mustPadDomainTag(s string) [domainTagLength]byte {
 	var tag [domainTagLength]byte
 
 	if len(s) > domainTagLength {
@@ -46,6 +46,16 @@ func paddedDomainTag(s string) [domainTagLength]byte {
 	copy(tag[:], s)
 
 	return tag
+}
+
+// padDomainTag returns a new padded domain tag from the given string. This function returns an error if the domain
+// tag is too long.
+func padDomainTag(tag string) (paddedTag [domainTagLength]byte, err error) {
+	if len(tag) > domainTagLength {
+		return paddedTag, fmt.Errorf("domain tag %s cannot be longer than %d characters", tag, domainTagLength)
+	}
+
+	return mustPadDomainTag(tag), nil
 }
 
 // SignUserMessage signs a message in the user domain.


### PR DESCRIPTION
Closes: #245

## Description

Added helper functions for generating account proof messages for signing.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
