### PR TITLE
Fix storage used example

### DIFF
--- a/examples/storage_usage/main.go
+++ b/examples/storage_usage/main.go
@@ -95,6 +95,8 @@ func StorageUsageDemo() {
 
 	// Add some flow to increase storage capacity
 	examples.FundAccountInEmulator(flowClient, demoAccount.Address, 1.0)
+	
+	serviceAcctKey.SequenceNumber++
 
 	// try to save a very large resource again. This time it should work.
 	txId = sendSaveLargeResourceTransaction(


### PR DESCRIPTION
## Description

I noticed that one of the examples doesn't work when working on https://github.com/onflow/flow-emulator/pull/127. I checked and it also doesn't work on the current version of the emulator.

I'm not sure when it stopped working, but I assume its when we made failing transactions also use up a sequence number, which was a while ago.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
