### PR TITLE
update add key to be compatible with new Cadence api

### DIFF
--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -154,7 +154,7 @@ func AddAccountContract(address flow.Address, contract Contract) *flow.Transacti
 }
 
 func addAccountKeyTemplate(sigAlgo crypto.SignatureAlgorithm, hashAlgo crypto.HashAlgorithm) string {
-	return `transaction(publicKey: String) {
+	return fmt.Sprintf(`transaction(publicKey: String) {
 		prepare(signer: AuthAccount) {
 			let pk = PublicKey(
 				publicKey: publicKey.decodeHex(),
@@ -163,7 +163,7 @@ func addAccountKeyTemplate(sigAlgo crypto.SignatureAlgorithm, hashAlgo crypto.Ha
 			acct.keys.add(key, hashAlgorithm: HashAlgorithm.%s, weight: 1000.0)
 		}
 	}
-	`
+	`, sigAlgo.String(), hashAlgo.String())
 }
 
 // AddAccountKey generates a transaction that adds a public key to an account.


### PR DESCRIPTION
Cadence is removing `addPublicKey` and `removePublicKey` in the secure-cadence version, so the sdk needs to no longer use these functions. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 
