### PR TITLE
Fix adding account key

### DIFF
--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -191,12 +191,11 @@ func AddAccountContract(address flow.Address, contract Contract) *flow.Transacti
 
 // AddAccountKey generates a transaction that adds a public key to an account.
 func AddAccountKey(address flow.Address, accountKey *flow.AccountKey) *flow.Transaction {
-	keyHex := hex.EncodeToString(accountKey.PublicKey.Encode())
-	cadencePublicKey := cadence.String(keyHex)
+	key := newKeyListValue(accountKey)
 
 	return flow.NewTransaction().
 		SetScript([]byte(templates.AddAccountKey)).
-		AddRawArgument(jsoncdc.MustEncode(cadencePublicKey)).
+		AddRawArgument(jsoncdc.MustEncode(key)).
 		AddAuthorizer(address)
 }
 


### PR DESCRIPTION
Adding the account key didn't use the new templates. This has been fixed.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
