### PR TITLE
Add account key changes

### DIFF
--- a/examples/add_account_key/main.go
+++ b/examples/add_account_key/main.go
@@ -50,7 +50,8 @@ func AddAccountKeyDemo() {
 		SetHashAlgo(crypto.SHA3_256).
 		SetWeight(flow.AccountKeyWeightThreshold)
 
-	addKeyTx := templates.AddAccountKey(acctAddr, myAcctKey)
+	addKeyTx, err := templates.AddAccountKey(acctAddr, myAcctKey)
+	examples.Handle(err)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
 

--- a/examples/create_account/main.go
+++ b/examples/create_account/main.go
@@ -49,7 +49,8 @@ func CreateAccountDemo() {
 		SetWeight(flow.AccountKeyWeightThreshold)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
-	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
+	createAccountTx, err := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
+	examples.Handle(err)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
 		serviceAcctKey.Index,

--- a/examples/deploy_contract/main.go
+++ b/examples/deploy_contract/main.go
@@ -55,7 +55,8 @@ func DeployContractDemo() {
 	mySigner := crypto.NewInMemorySigner(myPrivateKey, myAcctKey.HashAlgo)
 
 	referenceBlockID := examples.GetReferenceBlockId(flowClient)
-	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
+	createAccountTx, err := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
+	examples.Handle(err)
 	createAccountTx.SetProposalKey(
 		serviceAcctAddr,
 		serviceAcctKey.Index,
@@ -92,11 +93,12 @@ func DeployContractDemo() {
 
 	// Deploy the Great NFT contract
 	nftCode := examples.ReadFile(GreatTokenContractFile)
-	deployContractTx := templates.CreateAccount(nil,
+	deployContractTx, err := templates.CreateAccount(nil,
 		[]templates.Contract{{
 			Name:   "GreatToken",
 			Source: nftCode,
 		}}, serviceAcctAddr)
+	examples.Handle(err)
 
 	deployContractTx.SetProposalKey(
 		serviceAcctAddr,

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -154,13 +154,14 @@ func CreateAccountWithContracts(flowClient *client.Client, publicKeys []*flow.Ac
 
 	referenceBlockID := GetReferenceBlockId(flowClient)
 
-	createAccountTx := templates.CreateAccount(publicKeys, contracts, serviceAcctAddr)
+	createAccountTx, err := templates.CreateAccount(publicKeys, contracts, serviceAcctAddr)
+	Handle(err)
 	createAccountTx.
 		SetProposalKey(serviceAcctAddr, serviceAcctKey.Index, serviceAcctKey.SequenceNumber).
 		SetReferenceBlockID(referenceBlockID).
 		SetPayer(serviceAcctAddr)
 
-	err := createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
+	err = createAccountTx.SignEnvelope(serviceAcctAddr, serviceAcctKey.Index, serviceSigner)
 	Handle(err)
 
 	ctx := context.Background()

--- a/examples/modify_account/main.go
+++ b/examples/modify_account/main.go
@@ -89,7 +89,8 @@ func ModifyAccountDemo() {
 		SetWeight(flow.AccountKeyWeightThreshold)
 
 	// create a new account without any contracts
-	createAccountTx := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
+	createAccountTx, err := templates.CreateAccount([]*flow.AccountKey{myAcctKey}, nil, serviceAcctAddr)
+	examples.Handle(err)
 	prepareAndSendTx(ctx, flowClient, myAcctKey, *createAccountTx)
 
 	acc, err := flowClient.GetAccount(ctx, serviceAcctAddr)
@@ -134,7 +135,8 @@ func ModifyAccountDemo() {
 		SetHashAlgo(crypto.SHA3_256).
 		SetWeight(flow.AccountKeyWeightThreshold)
 
-	addKeyTx := templates.AddAccountKey(serviceAcctAddr, newAcctKey)
+	addKeyTx, err := templates.AddAccountKey(serviceAcctAddr, newAcctKey)
+	examples.Handle(err)
 	prepareAndSendTx(ctx, flowClient, myAcctKey, *addKeyTx)
 
 	acc, _ = flowClient.GetAccount(ctx, serviceAcctAddr)

--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -114,7 +114,18 @@ func newPublicKeyValue(pubKey crypto.PublicKey) cadence.Struct {
 	)
 }
 
-func newKeyListValue(key *flow.AccountKey) cadence.Struct {
+// AccountKeyToCadenceCryptoKey converts a `flow.AccountKe` key to the Cadence struct `Crypto.KeyListEntry`,
+// so that it can more easily be used as a parameter in scripts and transactions.
+//
+// example:
+// ```go
+// 	key := AccountKeyToCadenceCryptoKey(accountKey)
+//
+//	return flow.NewTransaction().
+//		SetScript([]byte(templates.AddAccountKey)).
+//		AddRawArgument(jsoncdc.MustEncode(key))
+// ```
+func AccountKeyToCadenceCryptoKey(key *flow.AccountKey) cadence.Value {
 	weight, _ := cadence.NewUFix64(fmt.Sprintf("%d.0", key.Weight))
 
 	return cadence.NewStruct([]cadence.Value{
@@ -160,7 +171,7 @@ func CreateAccount(accountKeys []*flow.AccountKey, contracts []Contract, payer f
 	contractKeyPairs := make([]cadence.KeyValuePair, len(contracts))
 
 	for i, key := range accountKeys {
-		keyList[i] = newKeyListValue(key)
+		keyList[i] = AccountKeyToCadenceCryptoKey(key)
 	}
 
 	for i, contract := range contracts {
@@ -206,7 +217,7 @@ func AddAccountContract(address flow.Address, contract Contract) *flow.Transacti
 
 // AddAccountKey generates a transaction that adds a public key to an account.
 func AddAccountKey(address flow.Address, accountKey *flow.AccountKey) *flow.Transaction {
-	key := newKeyListValue(accountKey)
+	key := AccountKeyToCadenceCryptoKey(accountKey)
 
 	return flow.NewTransaction().
 		SetScript([]byte(templates.AddAccountKey)).

--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -58,26 +58,16 @@ func exportType(t sema.Type) cadence.Type {
 }
 
 func newSignAlgoValue(sigAlgo crypto.SignatureAlgorithm) cadence.Enum {
-	sigAlgoCadence := sema.SignatureAlgorithmECDSA_P256
-	if sigAlgo == crypto.ECDSA_secp256k1 {
-		sigAlgoCadence = sema.SignatureAlgorithmECDSA_secp256k1
-	}
-
 	return cadence.NewEnum([]cadence.Value{
-		cadence.NewUInt8(sigAlgoCadence.RawValue()),
+		cadence.NewUInt8(uint8(sigAlgo)),
 	}).WithType(
 		exportType(sema.SignatureAlgorithmType).(*cadence.EnumType),
 	)
 }
 
 func newHashAlgoValue(hashAlgo crypto.HashAlgorithm) cadence.Enum {
-	hashAlgoCadence := sema.HashAlgorithmSHA3_256
-	if hashAlgo == crypto.SHA2_256 {
-		hashAlgoCadence = sema.HashAlgorithmSHA2_256
-	}
-
 	return cadence.NewEnum([]cadence.Value{
-		cadence.NewUInt8(hashAlgoCadence.RawValue()),
+		cadence.NewUInt8(uint8(hashAlgo)),
 	}).WithType(
 		exportType(sema.HashAlgorithmType).(*cadence.EnumType),
 	)

--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -114,7 +114,7 @@ func newPublicKeyValue(pubKey crypto.PublicKey) cadence.Struct {
 	)
 }
 
-// AccountKeyToCadenceCryptoKey converts a `flow.AccountKe` key to the Cadence struct `Crypto.KeyListEntry`,
+// AccountKeyToCadenceCryptoKey converts a `flow.AccountKey` key to the Cadence struct `Crypto.KeyListEntry`,
 // so that it can more easily be used as a parameter in scripts and transactions.
 //
 // example:

--- a/templates/accounts.go
+++ b/templates/accounts.go
@@ -21,7 +21,6 @@ package templates
 import (
 	"encoding/hex"
 	"fmt"
-
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime"
@@ -58,16 +57,42 @@ func exportType(t sema.Type) cadence.Type {
 }
 
 func newSignAlgoValue(sigAlgo crypto.SignatureAlgorithm) cadence.Enum {
+	sigAlgoValue := sema.SignatureAlgorithmECDSA_P256
+	switch sigAlgo {
+	case crypto.ECDSA_P256:
+		sigAlgoValue = sema.SignatureAlgorithmECDSA_P256
+	case crypto.ECDSA_secp256k1:
+		sigAlgoValue = sema.SignatureAlgorithmECDSA_secp256k1
+	default:
+		panic(fmt.Sprintf("unsupported signature algorithm: %v", sigAlgo))
+	}
+
 	return cadence.NewEnum([]cadence.Value{
-		cadence.NewUInt8(uint8(sigAlgo)),
+		cadence.NewUInt8(sigAlgoValue.RawValue()),
 	}).WithType(
 		exportType(sema.SignatureAlgorithmType).(*cadence.EnumType),
 	)
 }
 
 func newHashAlgoValue(hashAlgo crypto.HashAlgorithm) cadence.Enum {
+	hashAlgoValue := sema.HashAlgorithmSHA2_256
+	switch hashAlgo {
+	case crypto.SHA2_256:
+		hashAlgoValue = sema.HashAlgorithmSHA2_256
+	case crypto.SHA2_384:
+		hashAlgoValue = sema.HashAlgorithmSHA2_384
+	case crypto.SHA3_256:
+		hashAlgoValue = sema.HashAlgorithmSHA3_256
+	case crypto.SHA3_384:
+		hashAlgoValue = sema.HashAlgorithmSHA3_384
+	case crypto.Keccak256:
+		hashAlgoValue = sema.HashAlgorithmKECCAK_256
+	default:
+		panic(fmt.Sprintf("unsupported hash algorithm: %v", hashAlgo))
+	}
+
 	return cadence.NewEnum([]cadence.Value{
-		cadence.NewUInt8(uint8(hashAlgo)),
+		cadence.NewUInt8(hashAlgoValue.RawValue()),
 	}).WithType(
 		exportType(sema.HashAlgorithmType).(*cadence.EnumType),
 	)

--- a/templates/accounts_test.go
+++ b/templates/accounts_test.go
@@ -33,13 +33,15 @@ func TestCreateAccount(t *testing.T) {
 		contractLen := 1000
 		contractCode := make([]byte, contractLen)
 
-		tx := templates.CreateAccount(
+		tx, err := templates.CreateAccount(
 			[]*flow.AccountKey{},
 			[]templates.Contract{{
 				Name:   "contract",
 				Source: string(contractCode),
 			}},
 			flow.HexToAddress("01"))
+
+		require.NoError(t, err)
 
 		txSize := len(tx.Script)
 		argumentsSize := 0


### PR DESCRIPTION
## Description

Made AccountKeyToCadenceCryptoKey public so it can be used elsewhere as it is a very useful way to encode keys.

Changed newHashAlgoValue and  newSignAlgoValue because newHashAlgoValue was not able to encode some hash algos correclty.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
