### PR TITLE
Crypto: General clean up + KMS signing updates

### DIFF
--- a/account.go
+++ b/account.go
@@ -98,14 +98,8 @@ func (a AccountKey) Encode() []byte {
 // accountCompatibleAlgorithms returns true if the signature and hash algorithms are a valid pair
 // for a key on a Flow account.
 func accountCompatibleAlgorithms(sigAlgo crypto.SignatureAlgorithm, hashAlgo crypto.HashAlgorithm) bool {
-	switch sigAlgo {
-	case crypto.ECDSA_P256:
-		fallthrough
-	case crypto.ECDSA_secp256k1:
-		switch hashAlgo {
-		case crypto.SHA2_256:
-			fallthrough
-		case crypto.SHA3_256:
+	if sigAlgo == crypto.ECDSA_P256 || sigAlgo == crypto.ECDSA_secp256k1 {
+		if hashAlgo == crypto.SHA2_256 || hashAlgo == crypto.SHA3_256 {
 			return true
 		}
 	}

--- a/crypto/cloudkms/cloudkms_test.go
+++ b/crypto/cloudkms/cloudkms_test.go
@@ -68,9 +68,13 @@ func gcloudApplicationSignin(kms cloudkms.Key) error {
 }
 
 // TestManualKMSSigning tests signing using a KMS key.
-// This tests requires access to KMS and cannot be run by CI. Please use this test manually
+// This tests requires access to KMS and cannot be run by CI.
+// Please use this test manually by commenting t.Skip(),
 // when making any change to the KMS signing code.
 func TestManualKMSSigning(t *testing.T) {
+	// to comment when testing manually
+	t.Skip()
+
 	key := cloudkms.Key{
 		ProjectID:  "dl-flow",
 		LocationID: "us-east1",

--- a/crypto/cloudkms/cloudkms_test.go
+++ b/crypto/cloudkms/cloudkms_test.go
@@ -1,6 +1,11 @@
 package cloudkms_test
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +31,65 @@ func TestKeyFromResourceID(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, key, keyFromResourceID)
+}
+
+// gcloudApplicationSignin signs in as an application user using gcloud command line tool
+// currently assumes gcloud is already installed on the machine
+// will by default pop a browser window to sign in
+func gcloudApplicationSignin(kms cloudkms.Key) error {
+	googleAppCreds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if len(googleAppCreds) > 0 {
+		return nil
+	}
+
+	proj := kms.ProjectID
+	if len(proj) == 0 {
+		return fmt.Errorf(
+			"could not get GOOGLE_APPLICATION_CREDENTIALS, no google service account JSON provided but private key type is KMS",
+		)
+	}
+
+	loginCmd := exec.Command("gcloud", "auth", "application-default", "login", fmt.Sprintf("--project=%s", proj))
+
+	output, err := loginCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to run %q: %s\n", loginCmd.String(), err)
+	}
+
+	squareBracketRegex := regexp.MustCompile(`(?s)\[(.*)\]`)
+	regexResult := squareBracketRegex.FindAllStringSubmatch(string(output), -1)
+	// Should only be one value. Second index since first index contains the square brackets
+	googleApplicationCreds := regexResult[0][1]
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", googleApplicationCreds)
+
+	return nil
+}
+
+func TestManualKMSSigning(t *testing.T) {
+	key := cloudkms.Key{
+		ProjectID:  "dl-flow",
+		LocationID: "us-east1",
+		KeyRingID:  "testnet_keyring",
+		KeyID:      "sdk_test",
+		KeyVersion: "1",
+	}
+
+	// id is copied from the kms key: https://console.cloud.google.com/security/kms/key/manage/us-east1/testnet_keyring/sdk_test?project=dl-flow
+	// this test insures the key exists in the kms keyring
+	id := "projects/dl-flow/locations/us-east1/keyRings/testnet_keyring/cryptoKeys/sdk_test/cryptoKeyVersions/1"
+	require.Equal(t, key.ResourceID(), id)
+
+	// get google kms permission
+	err := gcloudApplicationSignin(key)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	cl, err := cloudkms.NewClient(ctx)
+	require.NoError(t, err)
+	// Get the public key
+	pk, _, err := cl.GetPublicKey(ctx, key)
+	require.NoError(t, err)
+	fmt.Println(pk)
+	// TODO: finish the test: sign and verify
 }

--- a/crypto/cloudkms/signer.go
+++ b/crypto/cloudkms/signer.go
@@ -127,7 +127,7 @@ func curveOrder(curve crypto.SignatureAlgorithm) int {
 	case crypto.ECDSA_secp256k1:
 		return 32
 	default:
-		return 0 // or panic? this only happens if there is an implementation bug
+		panic("the curve is not supported")
 	}
 }
 

--- a/crypto/cloudkms/signer.go
+++ b/crypto/cloudkms/signer.go
@@ -92,8 +92,9 @@ func (s *Signer) Sign(message []byte) ([]byte, error) {
 }
 
 func checksum(data []byte) *wrapperspb.Int64Value {
-	// compute the checksum
-	checksum := crc32.ChecksumIEEE(data)
+	// compute CRC32
+	table := crc32.MakeTable(crc32.Castagnoli)
+	checksum := crc32.Checksum(data, table)
 	val := wrapperspb.Int64(int64(checksum))
 	return val
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -59,16 +59,8 @@ func StringToSignatureAlgorithm(s string) SignatureAlgorithm {
 // The package currently supports ECDSA with the 2 curves P-256 and secp256k1. Both curves can be paired with
 // a supported hash function of 256-bits output (SHA2-256, SHA3-256, Keccak256)
 func CompatibleAlgorithms(sigAlgo SignatureAlgorithm, hashAlgo HashAlgorithm) bool {
-	switch sigAlgo {
-	case ECDSA_P256:
-		fallthrough
-	case ECDSA_secp256k1:
-		switch hashAlgo {
-		case SHA2_256:
-			fallthrough
-		case SHA3_256:
-			fallthrough
-		case Keccak256:
+	if sigAlgo == ECDSA_P256 || sigAlgo == ECDSA_secp256k1 {
+		if hashAlgo == SHA2_256 || hashAlgo == SHA3_256 || hashAlgo == Keccak256 {
 			return true
 		}
 	}

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -99,4 +99,6 @@ func NewSHA3_384() Hasher {
 }
 
 // NewKeccak_256 returns a new instance of Keccak256 hasher.
-var NewKeccak_256 = hash.NewKeccak_256
+func NewKeccak_256() Hasher {
+	return hash.NewKeccak_256()
+}


### PR DESCRIPTION
## Description

- update the KMS signer `Sign` function so that hashing is performed by KMS.
- add checksum check for signed data by KMS.
- add a manual test for KMS signing (skipped by CI)
- add Keccak256 to the package supported algorithms.
- tidy up the ECDSA curves/hash functions compatibility. In particular, separate compatibility for Flow account keys and compatibility of using ECDSA signature from the SDK.
- Closes: #193 (tidy up the support of secp256k1 by the kms signer).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
