### PR TITLE
Add new code owner for the crypto package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @psiemens @turbolent @janezpodhostnik @sideninja
+/crypto/** @tarakby


### PR DESCRIPTION
## Description

The crypto package of `flow-go-sdk` is based on the crypto package from `flow-go`. This PR adds the code owner of `flow-go/crypto`  (@tarakby) as a code owner to `flow-go-sdk/crypto` to make sure he is notified for future updates, in order to review the changes and help maintaining the package.

The crypto package still remains owned by the code owners of the `flow-go-sdk` repo.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
