### PR TITLE
Fix toTransactionResult to include blockID

### DIFF
--- a/access/http/convert.go
+++ b/access/http/convert.go
@@ -365,9 +365,10 @@ func toTransactionResult(txr *models.TransactionResult) (*flow.TransactionResult
 	}
 
 	return &flow.TransactionResult{
-		Status: toTransactionStatus(txr.Status),
-		Error:  txErr,
-		Events: events,
+		Status:  toTransactionStatus(txr.Status),
+		Error:   txErr,
+		Events:  events,
+		BlockID: flow.HexToID(txr.BlockId),
 	}, nil
 }
 

--- a/access/http/fixtures_test.go
+++ b/access/http/fixtures_test.go
@@ -146,6 +146,7 @@ func transactionResultFlowFixture() models.TransactionResult {
 	status := models.SEALED_TransactionStatus
 
 	return models.TransactionResult{
+		BlockId:      txr.BlockID.String(),
 		Status:       &status,
 		StatusCode:   0,
 		ErrorMessage: txr.Error.Error(),


### PR DESCRIPTION
Closes: #???

## Description

Added `BlockID` to `TransactionResult` in a return value of the convert function.

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
