### PR TITLE
Update to Cadence v0.24.4, allow passing JSON options

### DIFF
--- a/access/grpc/convert.go
+++ b/access/grpc/convert.go
@@ -211,8 +211,8 @@ func cadenceValuesToMessages(values []cadence.Value) ([][]byte, error) {
 	return msgs, nil
 }
 
-func messageToCadenceValue(m []byte) (cadence.Value, error) {
-	v, err := jsoncdc.Decode(nil, m)
+func messageToCadenceValue(m []byte, options []jsoncdc.Option) (cadence.Value, error) {
+	v, err := jsoncdc.Decode(nil, m, options...)
 	if err != nil {
 		return nil, fmt.Errorf("convert: %w", err)
 	}
@@ -337,8 +337,8 @@ func eventToMessage(e flow.Event) (*entities.Event, error) {
 	}, nil
 }
 
-func messageToEvent(m *entities.Event) (flow.Event, error) {
-	value, err := messageToCadenceValue(m.GetPayload())
+func messageToEvent(m *entities.Event, options []jsoncdc.Option) (flow.Event, error) {
+	value, err := messageToCadenceValue(m.GetPayload(), options)
 	if err != nil {
 		return flow.Event{}, err
 	}
@@ -503,12 +503,12 @@ func transactionResultToMessage(result flow.TransactionResult) (*access.Transact
 	}, nil
 }
 
-func messageToTransactionResult(m *access.TransactionResultResponse) (flow.TransactionResult, error) {
+func messageToTransactionResult(m *access.TransactionResultResponse, options []jsoncdc.Option) (flow.TransactionResult, error) {
 	eventMessages := m.GetEvents()
 
 	events := make([]flow.Event, len(eventMessages))
 	for i, eventMsg := range eventMessages {
-		event, err := messageToEvent(eventMsg)
+		event, err := messageToEvent(eventMsg, options)
 		if err != nil {
 			return flow.TransactionResult{}, err
 		}

--- a/access/grpc/convert_test.go
+++ b/access/grpc/convert_test.go
@@ -111,7 +111,7 @@ func TestConvert_CadenceValue(t *testing.T) {
 		msg, err := cadenceValueToMessage(valueA)
 		require.NoError(t, err)
 
-		valueB, err := messageToCadenceValue(msg)
+		valueB, err := messageToCadenceValue(msg, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, valueA, valueB)
@@ -120,7 +120,7 @@ func TestConvert_CadenceValue(t *testing.T) {
 	t.Run("Invalid message", func(t *testing.T) {
 		msg := []byte("invalid JSON-CDC bytes")
 
-		value, err := messageToCadenceValue(msg)
+		value, err := messageToCadenceValue(msg, nil)
 		assert.Error(t, err)
 		assert.Nil(t, value)
 	})
@@ -199,7 +199,7 @@ func TestConvert_Event(t *testing.T) {
 	msg, err := eventToMessage(eventA)
 	require.NoError(t, err)
 
-	eventB, err := messageToEvent(msg)
+	eventB, err := messageToEvent(msg, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, eventA, eventB)
@@ -261,7 +261,7 @@ func TestConvert_TransactionResult(t *testing.T) {
 
 	msg, err := transactionResultToMessage(resultA)
 
-	resultB, err := messageToTransactionResult(msg)
+	resultB, err := messageToTransactionResult(msg, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, resultA, resultB)

--- a/access/http/client_test.go
+++ b/access/http/client_test.go
@@ -38,7 +38,7 @@ func clientTest(
 	return func(t *testing.T) {
 		h := &mockHandler{}
 		client := &Client{
-			&BaseClient{h},
+			&BaseClient{handler: h},
 		}
 		f(context.Background(), t, h, client)
 		h.AssertExpectations(t)
@@ -318,7 +318,7 @@ func TestBaseClient_GetTransactionResult(t *testing.T) {
 		expectedTx, err := toTransaction(&httpTx)
 		assert.NoError(t, err)
 
-		expectedTxRes, err := toTransactionResult(&httpTxRes)
+		expectedTxRes, err := toTransactionResult(&httpTxRes, nil)
 		assert.NoError(t, err)
 
 		handler.
@@ -485,7 +485,7 @@ func TestBaseClient_GetEvents(t *testing.T) {
 
 	t.Run("Get For Height Range", clientTest(func(ctx context.Context, t *testing.T, handler *mockHandler, client *Client) {
 		httpEvents := blockEventsFlowFixture()
-		expectedEvents, err := toBlockEvents([]models.BlockEvents{httpEvents})
+		expectedEvents, err := toBlockEvents([]models.BlockEvents{httpEvents}, nil)
 		const eType = "A.Foo.Bar"
 		handler.
 			On(handlerName, mock.Anything, eType, "0", "5", []string(nil)).
@@ -498,7 +498,7 @@ func TestBaseClient_GetEvents(t *testing.T) {
 
 	t.Run("Get For Block IDs", clientTest(func(ctx context.Context, t *testing.T, handler *mockHandler, client *Client) {
 		httpEvents := blockEventsFlowFixture()
-		expectedEvents, err := toBlockEvents([]models.BlockEvents{httpEvents})
+		expectedEvents, err := toBlockEvents([]models.BlockEvents{httpEvents}, nil)
 		const eType = "A.Foo.Bar"
 		handler.
 			On(handlerName, mock.Anything, eType, "", "", []string{expectedEvents[0].BlockID.String()}).

--- a/access/http/convert.go
+++ b/access/http/convert.go
@@ -235,13 +235,13 @@ func encodeCadenceArgs(args []cadence.Value) ([]string, error) {
 	return encArgs, nil
 }
 
-func encodeCadenceValue(value string) (cadence.Value, error) {
+func decodeCadenceValue(value string, options []cadenceJSON.Option) (cadence.Value, error) {
 	decoded, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return nil, err
 	}
 
-	return cadenceJSON.Decode(nil, decoded)
+	return cadenceJSON.Decode(nil, decoded, options...)
 }
 
 func toProposalKey(key *models.ProposalKey) flow.ProposalKey {
@@ -310,7 +310,7 @@ func toTransactionStatus(status *models.TransactionStatus) flow.TransactionStatu
 	}
 }
 
-func toEvents(events []models.Event) ([]flow.Event, error) {
+func toEvents(events []models.Event, options []cadenceJSON.Option) ([]flow.Event, error) {
 	flowEvents := make([]flow.Event, len(events))
 	for i, e := range events {
 		payload, err := base64.StdEncoding.DecodeString(e.Payload)
@@ -318,7 +318,7 @@ func toEvents(events []models.Event) ([]flow.Event, error) {
 			return nil, err
 		}
 
-		event, err := cadenceJSON.Decode(nil, payload)
+		event, err := cadenceJSON.Decode(nil, payload, options...)
 		if err != nil {
 			return nil, err
 		}
@@ -335,10 +335,10 @@ func toEvents(events []models.Event) ([]flow.Event, error) {
 	return flowEvents, nil
 }
 
-func toBlockEvents(blockEvents []models.BlockEvents) ([]flow.BlockEvents, error) {
+func toBlockEvents(blockEvents []models.BlockEvents, options []cadenceJSON.Option) ([]flow.BlockEvents, error) {
 	blocks := make([]flow.BlockEvents, len(blockEvents))
 	for i, block := range blockEvents {
-		events, err := toEvents(block.Events)
+		events, err := toEvents(block.Events, options)
 		if err != nil {
 			return nil, err
 		}
@@ -353,8 +353,8 @@ func toBlockEvents(blockEvents []models.BlockEvents) ([]flow.BlockEvents, error)
 	return blocks, nil
 }
 
-func toTransactionResult(txr *models.TransactionResult) (*flow.TransactionResult, error) {
-	events, err := toEvents(txr.Events)
+func toTransactionResult(txr *models.TransactionResult, options []cadenceJSON.Option) (*flow.TransactionResult, error) {
+	events, err := toEvents(txr.Events, options)
 	if err != nil {
 		return nil, err
 	}

--- a/access/http/convert_test.go
+++ b/access/http/convert_test.go
@@ -103,7 +103,7 @@ func Test_ConvertTransaction(t *testing.T) {
 
 func Test_ConvertTransactionResult(t *testing.T) {
 	httpTxr := transactionResultFlowFixture()
-	txr, err := toTransactionResult(&httpTxr)
+	txr, err := toTransactionResult(&httpTxr, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, txr.Status, flow.TransactionStatusSealed)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go/kms v1.4.0
 	github.com/ethereum/go-ethereum v1.9.13
-	github.com/onflow/cadence v0.24.3
+	github.com/onflow/cadence v0.24.4
 	github.com/onflow/flow-go/crypto v0.24.3
 	github.com/onflow/flow/protobuf/go/flow v0.2.5
 	github.com/onflow/sdks v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a h1:ldQ7U2iddVJCwJA2ckK7y6AdH4INzxOSu2VnejkcBro=
 github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a/go.mod h1:PZESmRR4bI/w/9nEDCqRoWxBq/jFNUEzkfypHf0j8cw=
-github.com/onflow/cadence v0.24.3 h1:UhggdTeTbxZraB9vkR7TlRv3i05nHDisFzo8SNzDZ0c=
-github.com/onflow/cadence v0.24.3/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
+github.com/onflow/cadence v0.24.4 h1:3f7wk1WFKvBlwjh3d1//5frJKFgECK2GxljoG4wzQqs=
+github.com/onflow/cadence v0.24.4/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/flow-go/crypto v0.24.3 h1:5puosmiy853m1GPmBLJr4PiLVcCzE4n5o60hRPo9kYA=
 github.com/onflow/flow-go/crypto v0.24.3/go.mod h1:dkVL98P6GHR48iD9zCB6XlnkJX8IQd00FKgt1reV90w=
 github.com/onflow/flow/protobuf/go/flow v0.2.5 h1:IzkN5f3w/qFN2Mshc1I0yNgnT+YbFE5Htz/h8t/VL4c=

--- a/transaction.go
+++ b/transaction.go
@@ -151,7 +151,7 @@ func (t *Transaction) AddRawArgument(arg []byte) *Transaction {
 }
 
 // Argument returns the decoded argument at the given index.
-func (t *Transaction) Argument(i int) (cadence.Value, error) {
+func (t *Transaction) Argument(i int, options ...jsoncdc.Option) (cadence.Value, error) {
 	if i < 0 {
 		return nil, fmt.Errorf("argument index must be positive")
 	}
@@ -162,7 +162,7 @@ func (t *Transaction) Argument(i int) (cadence.Value, error) {
 
 	encodedArg := t.Arguments[i]
 
-	arg, err := jsoncdc.Decode(nil, encodedArg)
+	arg, err := jsoncdc.Decode(nil, encodedArg, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode argument at index %d: %w", i, err)
 	}


### PR DESCRIPTION
## Description

https://github.com/onflow/cadence/pull/1733  added support for decoding Cadence JSON values that were encoded using the previous format. 

Update to Cadence v0.24.4 which contains this feature, and add support for allowing users of the SDK to pass JSON options. 

By adding the options to the client, all the `Client` functions can stay as-is.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
