### PR TITLE
Fix access http post error response

### DIFF
--- a/access/http/handler.go
+++ b/access/http/handler.go
@@ -149,7 +149,7 @@ func (h *httpHandler) post(_ context.Context, url *url.URL, body []byte, model i
 		}
 
 		var httpErr HTTPError
-		err = json.Unmarshal(body, &httpErr)
+		err = json.Unmarshal(responseBody, &httpErr)
 		if err != nil {
 			return err
 		}

--- a/access/http/handler_test.go
+++ b/access/http/handler_test.go
@@ -358,7 +358,7 @@ func TestHandler_ExecuteScript(t *testing.T) {
 		)
 
 		_, err := handler.executeScriptAtBlockHeight(ctx, height, script, nil)
-		assert.EqualError(t, err, "executing script main() { return 42; } failed: ") // todo check desc
+		assert.EqualError(t, err, "executing script main() { return 42; } failed: execution failure") // todo check desc
 	}))
 }
 
@@ -375,6 +375,25 @@ func TestHandler_SendTransaction(t *testing.T) {
 
 		err = handler.sendTransaction(ctx, rawTx)
 		assert.NoError(t, err)
+	}))
+
+	t.Run("Invalid Argument", handlerTest(func(ctx context.Context, t *testing.T, handler httpHandler, req *testRequest) {
+		httpTx := transactionFlowFixture()
+		u, _ := url.Parse("/transactions")
+
+		req.SetErr(
+			*u,
+			models.ModelError{
+				Code:    http.StatusBadRequest,
+				Message: "rpc error: code = InvalidArgument",
+			},
+		)
+
+		rawTx, err := json.Marshal(httpTx)
+		assert.NoError(t, err)
+
+		err = handler.sendTransaction(ctx, rawTx)
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument")
 	}))
 }
 


### PR DESCRIPTION
Closes: #???

## Description

Fixed HTTP post error response message to be included in the error returned by the handler. 

HTTP post has been returning empty error message like below.
```go
http.HTTPError{
  Url:     "http://127.0.0.1:8888/v1/transactions",
  Code:    0,
  Message: "",
}
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
