### PR TITLE
Allow Cadence Unstructured Static Types

### DIFF
--- a/access/grpc/grpc.go
+++ b/access/grpc/grpc.go
@@ -56,8 +56,9 @@ func NewBaseClient(url string, opts ...grpc.DialOption) (*BaseClient, error) {
 	grpcClient := access.NewAccessAPIClient(conn)
 
 	return &BaseClient{
-		rpcClient: grpcClient,
-		close:     func() error { return conn.Close() },
+		rpcClient:   grpcClient,
+		close:       func() error { return conn.Close() },
+		jsonOptions: []json.Option{json.WithAllowUnstructuredStaticTypes(true)},
 	}, nil
 }
 

--- a/access/http/http.go
+++ b/access/http/http.go
@@ -156,7 +156,12 @@ func NewBaseClient(host string) (*BaseClient, error) {
 		return nil, err
 	}
 
-	return &BaseClient{handler: handler}, nil
+	return &BaseClient{
+		handler: handler,
+		jsonOptions: []json.Option{
+			json.WithAllowUnstructuredStaticTypes(true),
+		},
+	}, nil
 }
 
 // BaseClient provides an API specific to the HTTP.


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-cli/issues/543

## Description
By default add the cadence JSON parsing option to allow pre-fork formats.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
