### PR TITLE
Add BlockHeight to TransactionResult

### DIFF
--- a/access/grpc/convert.go
+++ b/access/grpc/convert.go
@@ -500,6 +500,7 @@ func transactionResultToMessage(result flow.TransactionResult) (*access.Transact
 		ErrorMessage: errorMsg,
 		Events:       eventMessages,
 		BlockId:      identifierToMessage(result.BlockID),
+		BlockHeight:  result.BlockHeight,
 	}, nil
 }
 
@@ -529,9 +530,10 @@ func messageToTransactionResult(m *access.TransactionResultResponse, options []j
 	}
 
 	return flow.TransactionResult{
-		Status:  flow.TransactionStatus(m.GetStatus()),
-		Error:   err,
-		Events:  events,
-		BlockID: flow.BytesToID(m.GetBlockId()),
+		Status:      flow.TransactionStatus(m.GetStatus()),
+		Error:       err,
+		Events:      events,
+		BlockID:     flow.BytesToID(m.GetBlockId()),
+		BlockHeight: m.BlockHeight,
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.13
 	github.com/onflow/cadence v0.24.2-0.20220627202951-5a06fec82b4a
 	github.com/onflow/flow-go/crypto v0.24.3
-	github.com/onflow/flow/protobuf/go/flow v0.2.5
+	github.com/onflow/flow/protobuf/go/flow v0.3.1
 	github.com/onflow/sdks v0.4.4
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.5

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/onflow/cadence v0.24.2-0.20220627202951-5a06fec82b4a h1:Wr7+zfFj7ehr3
 github.com/onflow/cadence v0.24.2-0.20220627202951-5a06fec82b4a/go.mod h1:g19FlFrcQsiegiZDe6wYtUCBO8O1hM1x/+l68aVO07k=
 github.com/onflow/flow-go/crypto v0.24.3 h1:5puosmiy853m1GPmBLJr4PiLVcCzE4n5o60hRPo9kYA=
 github.com/onflow/flow-go/crypto v0.24.3/go.mod h1:dkVL98P6GHR48iD9zCB6XlnkJX8IQd00FKgt1reV90w=
-github.com/onflow/flow/protobuf/go/flow v0.2.5 h1:IzkN5f3w/qFN2Mshc1I0yNgnT+YbFE5Htz/h8t/VL4c=
-github.com/onflow/flow/protobuf/go/flow v0.2.5/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
+github.com/onflow/flow/protobuf/go/flow v0.3.1 h1:4I8ykG6naR3n8Or6eXrZDaGVaoztb3gP2KJ6XKyDufg=
+github.com/onflow/flow/protobuf/go/flow v0.3.1/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/sdks v0.4.4 h1:aJPGJJLAN+mlBWAQxsyuJXeRRMFeLwU6Mp4e/YL6bdU=
 github.com/onflow/sdks v0.4.4/go.mod h1:F0dj0EyHC55kknLkeD10js4mo14yTdMotnWMslPirrU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/test/entities.go
+++ b/test/entities.go
@@ -421,6 +421,7 @@ func (g *TransactionResults) New() flow.TransactionResult {
 	eventA := g.events.New()
 	eventB := g.events.New()
 	blockID := newIdentifier(1)
+	blockHeight := uint64(42)
 
 	return flow.TransactionResult{
 		Status: flow.TransactionStatusSealed,
@@ -429,6 +430,7 @@ func (g *TransactionResults) New() flow.TransactionResult {
 			eventA,
 			eventB,
 		},
-		BlockID: blockID,
+		BlockID:     blockID,
+		BlockHeight: blockHeight,
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -609,10 +609,11 @@ func (s signaturesList) canonicalForm() []transactionSignatureCanonicalForm {
 }
 
 type TransactionResult struct {
-	Status  TransactionStatus
-	Error   error
-	Events  []Event
-	BlockID Identifier
+	Status      TransactionStatus
+	Error       error
+	Events      []Event
+	BlockID     Identifier
+	BlockHeight uint64
 }
 
 // TransactionStatus represents the status of a transaction.


### PR DESCRIPTION
Closes: #307 

## Description

Add missing BlockHeight to the TransactionResult.  Note that this update is only for the GRPC API call and does not update the HTTP endpoint.  Comments in issue refer requiring openapi schema needing updates so new models can be generated, out of scope for this PR.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
