### PR TITLE
Update address generator to match the flow-go

### DIFF
--- a/address.go
+++ b/address.go
@@ -107,11 +107,13 @@ func chainCustomizer(chain ChainID) uint64 {
 	case Mainnet:
 		return 0
 	case Testnet:
-		return invalidCodeTestnet
-	case Emulator:
-		return invalidCodeEmulator
+		return invalidCodeTestNetwork
+	case Stagingnet:
+		return invalidCodeStagingNetwork
+	case Emulator, Localnet, Benchnet, BftTestnet:
+		return invalidCodeTransientNetwork
 	default:
-		panic("chain ID is invalid")
+		panic(fmt.Sprintf("chain ID [%s] is invalid or does not support linear code address generation", chain))
 	}
 }
 
@@ -261,8 +263,14 @@ func (a *Address) IsValid(chain ChainID) bool {
 // invalid code-words in the [64,45] code
 // these constants are used to generate non-Flow-Mainnet addresses
 const (
-	invalidCodeTestnet  = uint64(0x6834ba37b3980209)
-	invalidCodeEmulator = uint64(0x1cb159857af02018)
+	// invalidCodeTestNetwork is the invalid codeword used for long-lived test networks.
+	invalidCodeTestNetwork = uint64(0x6834ba37b3980209)
+
+	// invalidCodeTransientNetwork  is the invalid codeword used for transient test networks.
+	invalidCodeTransientNetwork = uint64(0x1cb159857af02018)
+
+	// invalidCodeStagingNetwork is the invalid codeword used for Staging network.
+	invalidCodeStagingNetwork = uint64(0x1035ce4eff92ae01)
 )
 
 // Rows of the generator matrix G of the [64,45]-code used for Flow addresses.

--- a/flow.go
+++ b/flow.go
@@ -95,14 +95,32 @@ func HashToStateCommitment(hash []byte) StateCommitment {
 // Chain IDs are used used to prevent replay attacks and to support network-specific address generation.
 type ChainID string
 
-// Mainnet is the chain ID for the mainnet node chain.
-const Mainnet ChainID = "flow-mainnet"
+const (
+	// Mainnet is the chain ID for the mainnet chain.
+	Mainnet ChainID = "flow-mainnet"
 
-// Testnet is the chain ID for the testnet node chain.
-const Testnet ChainID = "flow-testnet"
+	// Long-lived test networks
 
-// Emulator is the chain ID for the emulated node chain.
-const Emulator ChainID = "flow-emulator"
+	// Testnet is the chain ID for the testnet chain.
+	Testnet ChainID = "flow-testnet"
+
+	// Stagingnet is the chain ID for internal stagingnet chain.
+	Stagingnet ChainID = "flow-stagingnet"
+
+	// Transient test networks
+
+	// Benchnet is the chain ID for the transient benchmarking chain.
+	Benchnet ChainID = "flow-benchnet"
+	// Localnet is the chain ID for the local development chain.
+	Localnet ChainID = "flow-localnet"
+	// Emulator is the chain ID for the emulated chain.
+	Emulator ChainID = "flow-emulator"
+	// BftTestnet is the chain ID for testing attack vector scenarios.
+	BftTestnet ChainID = "flow-bft-test-net"
+
+	// MonotonicEmulator is the chain ID for the emulated node chain with monotonic address generation.
+	MonotonicEmulator ChainID = "flow-emulator-monotonic"
+)
 
 func (id ChainID) String() string {
 	return string(id)


### PR DESCRIPTION

## Description
Address generator on flow-go supports more type of networks, updating the files here to match the one on the flow-go, 
If won't impact previously existed network names here just support more networks like benchnet. 
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
