### PR TITLE
Update index.mdx to remove invalid style tag

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -17,7 +17,7 @@ SDKs are open source, and you can use them according to the licence.
 
 The library client specifications can be found here:
 
-[<img style="margin: 0px;" src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/ref.svg" width="130" />](https://pkg.go.dev/github.com/onflow/flow-go-sdk/client)
+[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/ref.svg" width="130" />](https://pkg.go.dev/github.com/onflow/flow-go-sdk/client)
 
 
 ## Getting Started


### PR DESCRIPTION
Closes: [onflow/next-docs-v1#](https://github.com/onflow/next-docs-v1/issues/528)

## Description

The `style` tag here is causing this file to fail to compile on the new docs site because JSX requires `style`s to be an object mapping and not raw strings. I removed the style attribute entirely because it seems mostly unnecessary? But I'm not 100% sure if it's needed for some other reason, so I am happy add it back using `style={{ margin: 0 }}` if preferred!

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
