### PR TITLE
Remove psiemens as default issue assignee

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,8 +3,6 @@ name: Bug Report
 about: Report a problem or bug
 title: ''
 labels: bug
-assignees: psiemens
-
 ---
 
 ## Instructions 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature Request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: psiemens
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
I'd love to review all issues, but probably best that somebody else is tagged on these since I'm no longer the primary maintainer!
