### PR TITLE
remove '/' from the end of the rest access URI

### DIFF
--- a/access/http/client.go
+++ b/access/http/client.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	EmulatorHost  = "http://127.0.0.1:8888/v1"
-	TestnetHost   = "https://rest-testnet.onflow.org/v1/"
-	MainnetHost   = "https://rest-mainnet.onflow.org/v1/"
-	CanarynetHost = "https://rest-canary.onflow.org/v1/"
+	TestnetHost   = "https://rest-testnet.onflow.org/v1"
+	MainnetHost   = "https://rest-mainnet.onflow.org/v1"
+	CanarynetHost = "https://rest-canary.onflow.org/v1"
 )
 
 // NewClient creates an HTTP client exposing all the common access APIs.


### PR DESCRIPTION
It was preventing the http client to work.

Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
