### PR TITLE
Add sandboxnet ID

### DIFF
--- a/address.go
+++ b/address.go
@@ -108,8 +108,8 @@ func chainCustomizer(chain ChainID) uint64 {
 		return 0
 	case Testnet:
 		return invalidCodeTestNetwork
-	case Stagingnet:
-		return invalidCodeStagingNetwork
+	case Sandboxnet:
+		return invalidCodeSandboxNetwork
 	case Emulator, Localnet, Benchnet, BftTestnet:
 		return invalidCodeTransientNetwork
 	default:
@@ -269,8 +269,8 @@ const (
 	// invalidCodeTransientNetwork  is the invalid codeword used for transient test networks.
 	invalidCodeTransientNetwork = uint64(0x1cb159857af02018)
 
-	// invalidCodeStagingNetwork is the invalid codeword used for Staging network.
-	invalidCodeStagingNetwork = uint64(0x1035ce4eff92ae01)
+	// invalidCodeSandboxNetwork is the invalid codeword used for Sandbox network.
+	invalidCodeSandboxNetwork = uint64(0x1035ce4eff92ae01)
 )
 
 // Rows of the generator matrix G of the [64,45]-code used for Flow addresses.

--- a/flow.go
+++ b/flow.go
@@ -104,8 +104,8 @@ const (
 	// Testnet is the chain ID for the testnet chain.
 	Testnet ChainID = "flow-testnet"
 
-	// Stagingnet is the chain ID for internal stagingnet chain.
-	Stagingnet ChainID = "flow-stagingnet"
+	// Sandboxnet is the chain ID for sandboxnet chain.
+	Sandboxnet ChainID = "flow-sandboxnet"
 
 	// Transient test networks
 


### PR DESCRIPTION
Closes: #327 

## Description

Adds flow-sandboxnet as a valide chain ID, to match flow-go.

mostly a re-name, from stagingnet to sandboxnet

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
