### PR TITLE
Block status for sdk block functions

### DIFF
--- a/access/client.go
+++ b/access/client.go
@@ -35,13 +35,13 @@ type Client interface {
 	Ping(ctx context.Context) error
 
 	// GetLatestBlockHeader gets the latest sealed or unsealed block header.
-	GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, error)
+	GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, flow.BlockStatus, error)
 
 	// GetBlockHeaderByID gets a block header by ID.
-	GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, error)
+	GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, flow.BlockStatus, error)
 
 	// GetBlockHeaderByHeight gets a block header by height.
-	GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, error)
+	GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, flow.BlockStatus, error)
 
 	// GetLatestBlock gets the full payload of the latest sealed or unsealed block.
 	GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block, error)

--- a/access/grpc/client.go
+++ b/access/grpc/client.go
@@ -78,15 +78,15 @@ func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*fl
 	return c.grpc.GetBlockHeaderByHeight(ctx, height)
 }
 
-func (c *Client) GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block, flow.BlockStatus, error) {
+func (c *Client) GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block, error) {
 	return c.grpc.GetLatestBlock(ctx, isSealed)
 }
 
-func (c *Client) GetBlockByID(ctx context.Context, blockID flow.Identifier) (*flow.Block, flow.BlockStatus, error) {
+func (c *Client) GetBlockByID(ctx context.Context, blockID flow.Identifier) (*flow.Block, error) {
 	return c.grpc.GetBlockByID(ctx, blockID)
 }
 
-func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Block, flow.BlockStatus, error) {
+func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Block, error) {
 	return c.grpc.GetBlockByHeight(ctx, height)
 }
 

--- a/access/grpc/client.go
+++ b/access/grpc/client.go
@@ -66,27 +66,27 @@ func (c *Client) Ping(ctx context.Context) error {
 	return c.grpc.Ping(ctx)
 }
 
-func (c *Client) GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, error) {
+func (c *Client) GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, flow.BlockStatus, error) {
 	return c.grpc.GetLatestBlockHeader(ctx, isSealed)
 }
 
-func (c *Client) GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, error) {
+func (c *Client) GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, flow.BlockStatus, error) {
 	return c.grpc.GetBlockHeaderByID(ctx, blockID)
 }
 
-func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, error) {
+func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, flow.BlockStatus, error) {
 	return c.grpc.GetBlockHeaderByHeight(ctx, height)
 }
 
-func (c *Client) GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block, error) {
+func (c *Client) GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block, flow.BlockStatus, error) {
 	return c.grpc.GetLatestBlock(ctx, isSealed)
 }
 
-func (c *Client) GetBlockByID(ctx context.Context, blockID flow.Identifier) (*flow.Block, error) {
+func (c *Client) GetBlockByID(ctx context.Context, blockID flow.Identifier) (*flow.Block, flow.BlockStatus, error) {
 	return c.grpc.GetBlockByID(ctx, blockID)
 }
 
-func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Block, error) {
+func (c *Client) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Block, flow.BlockStatus, error) {
 	return c.grpc.GetBlockByHeight(ctx, height)
 }
 

--- a/access/grpc/convert.go
+++ b/access/grpc/convert.go
@@ -124,7 +124,7 @@ func blockToMessage(b flow.Block) (*entities.Block, error) {
 	}, nil
 }
 
-func messageToBlock(m *entities.Block) (flow.Block, error) {
+func messageToBlock(m *entities.Block, status flow.BlockStatus) (flow.Block, error) {
 	var timestamp time.Time
 	var err error
 
@@ -157,6 +157,7 @@ func messageToBlock(m *entities.Block) (flow.Block, error) {
 	return flow.Block{
 		BlockHeader:  *header,
 		BlockPayload: *payload,
+		Status:       status,
 	}, nil
 }
 

--- a/access/grpc/convert_test.go
+++ b/access/grpc/convert_test.go
@@ -58,7 +58,7 @@ func TestConvert_Block(t *testing.T) {
 	msg, err := blockToMessage(*blockA)
 	require.NoError(t, err)
 
-	blockB, err := messageToBlock(msg)
+	blockB, err := messageToBlock(msg, flow.BlockStatusUnknown)
 	require.NoError(t, err)
 
 	assert.Equal(t, *blockA, blockB)
@@ -71,7 +71,7 @@ func TestConvert_Block(t *testing.T) {
 
 		msg.Timestamp = nil
 
-		blockB, err = messageToBlock(msg)
+		blockB, err = messageToBlock(msg, flow.BlockStatusUnknown)
 		require.NoError(t, err)
 
 		assert.Equal(t, time.Time{}, blockB.Timestamp)

--- a/access/grpc/grpc.go
+++ b/access/grpc/grpc.go
@@ -88,7 +88,7 @@ func (c *BaseClient) GetLatestBlockHeader(
 	ctx context.Context,
 	isSealed bool,
 	opts ...grpc.CallOption,
-) (*flow.BlockHeader, error) {
+) (*flow.BlockHeader, flow.BlockStatus, error) {
 
 	req := &access.GetLatestBlockHeaderRequest{
 		IsSealed: isSealed,
@@ -96,7 +96,7 @@ func (c *BaseClient) GetLatestBlockHeader(
 
 	res, err := c.rpcClient.GetLatestBlockHeader(ctx, req, opts...)
 	if err != nil {
-		return nil, newRPCError(err)
+		return nil, flow.BlockStatusUnknown, newRPCError(err)
 	}
 
 	return getBlockHeaderResult(res)
@@ -106,14 +106,14 @@ func (c *BaseClient) GetBlockHeaderByID(
 	ctx context.Context,
 	blockID flow.Identifier,
 	opts ...grpc.CallOption,
-) (*flow.BlockHeader, error) {
+) (*flow.BlockHeader, flow.BlockStatus, error) {
 	req := &access.GetBlockHeaderByIDRequest{
 		Id: blockID.Bytes(),
 	}
 
 	res, err := c.rpcClient.GetBlockHeaderByID(ctx, req, opts...)
 	if err != nil {
-		return nil, newRPCError(err)
+		return nil, flow.BlockStatusUnknown, newRPCError(err)
 	}
 
 	return getBlockHeaderResult(res)
@@ -123,40 +123,40 @@ func (c *BaseClient) GetBlockHeaderByHeight(
 	ctx context.Context,
 	height uint64,
 	opts ...grpc.CallOption,
-) (*flow.BlockHeader, error) {
+) (*flow.BlockHeader, flow.BlockStatus, error) {
 	req := &access.GetBlockHeaderByHeightRequest{
 		Height: height,
 	}
 
 	res, err := c.rpcClient.GetBlockHeaderByHeight(ctx, req, opts...)
 	if err != nil {
-		return nil, newRPCError(err)
+		return nil, flow.BlockStatusUnknown, newRPCError(err)
 	}
 
 	return getBlockHeaderResult(res)
 }
 
-func getBlockHeaderResult(res *access.BlockHeaderResponse) (*flow.BlockHeader, error) {
+func getBlockHeaderResult(res *access.BlockHeaderResponse) (*flow.BlockHeader, flow.BlockStatus, error) {
 	header, err := messageToBlockHeader(res.GetBlock())
 	if err != nil {
-		return nil, newMessageToEntityError(entityBlockHeader, err)
+		return nil, flow.BlockStatusUnknown, newMessageToEntityError(entityBlockHeader, err)
 	}
 
-	return &header, nil
+	return &header, flow.BlockStatus(res.GetBlockStatus()), nil
 }
 
 func (c *BaseClient) GetLatestBlock(
 	ctx context.Context,
 	isSealed bool,
 	opts ...grpc.CallOption,
-) (*flow.Block, error) {
+) (*flow.Block, flow.BlockStatus, error) {
 	req := &access.GetLatestBlockRequest{
 		IsSealed: isSealed,
 	}
 
 	res, err := c.rpcClient.GetLatestBlock(ctx, req, opts...)
 	if err != nil {
-		return nil, newRPCError(err)
+		return nil, flow.BlockStatusUnknown, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -166,14 +166,14 @@ func (c *BaseClient) GetBlockByID(
 	ctx context.Context,
 	blockID flow.Identifier,
 	opts ...grpc.CallOption,
-) (*flow.Block, error) {
+) (*flow.Block, flow.BlockStatus, error) {
 	req := &access.GetBlockByIDRequest{
 		Id: blockID.Bytes(),
 	}
 
 	res, err := c.rpcClient.GetBlockByID(ctx, req, opts...)
 	if err != nil {
-		return nil, newRPCError(err)
+		return nil, flow.BlockStatusUnknown, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -183,26 +183,26 @@ func (c *BaseClient) GetBlockByHeight(
 	ctx context.Context,
 	height uint64,
 	opts ...grpc.CallOption,
-) (*flow.Block, error) {
+) (*flow.Block, flow.BlockStatus, error) {
 	req := &access.GetBlockByHeightRequest{
 		Height: height,
 	}
 
 	res, err := c.rpcClient.GetBlockByHeight(ctx, req, opts...)
 	if err != nil {
-		return nil, newRPCError(err)
+		return nil, flow.BlockStatusUnknown, newRPCError(err)
 	}
 
 	return getBlockResult(res)
 }
 
-func getBlockResult(res *access.BlockResponse) (*flow.Block, error) {
+func getBlockResult(res *access.BlockResponse) (*flow.Block, flow.BlockStatus, error) {
 	block, err := messageToBlock(res.GetBlock())
 	if err != nil {
-		return nil, newMessageToEntityError(entityBlock, err)
+		return nil, flow.BlockStatusUnknown, newMessageToEntityError(entityBlock, err)
 	}
 
-	return &block, nil
+	return &block, flow.BlockStatus(res.GetBlockStatus()), nil
 }
 
 func (c *BaseClient) GetCollection(

--- a/access/grpc/grpc.go
+++ b/access/grpc/grpc.go
@@ -149,14 +149,14 @@ func (c *BaseClient) GetLatestBlock(
 	ctx context.Context,
 	isSealed bool,
 	opts ...grpc.CallOption,
-) (*flow.Block, flow.BlockStatus, error) {
+) (*flow.Block, error) {
 	req := &access.GetLatestBlockRequest{
 		IsSealed: isSealed,
 	}
 
 	res, err := c.rpcClient.GetLatestBlock(ctx, req, opts...)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, newRPCError(err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -166,14 +166,14 @@ func (c *BaseClient) GetBlockByID(
 	ctx context.Context,
 	blockID flow.Identifier,
 	opts ...grpc.CallOption,
-) (*flow.Block, flow.BlockStatus, error) {
+) (*flow.Block, error) {
 	req := &access.GetBlockByIDRequest{
 		Id: blockID.Bytes(),
 	}
 
 	res, err := c.rpcClient.GetBlockByID(ctx, req, opts...)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, newRPCError(err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockResult(res)
@@ -183,26 +183,26 @@ func (c *BaseClient) GetBlockByHeight(
 	ctx context.Context,
 	height uint64,
 	opts ...grpc.CallOption,
-) (*flow.Block, flow.BlockStatus, error) {
+) (*flow.Block, error) {
 	req := &access.GetBlockByHeightRequest{
 		Height: height,
 	}
 
 	res, err := c.rpcClient.GetBlockByHeight(ctx, req, opts...)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, newRPCError(err)
+		return nil, newRPCError(err)
 	}
 
 	return getBlockResult(res)
 }
 
-func getBlockResult(res *access.BlockResponse) (*flow.Block, flow.BlockStatus, error) {
-	block, err := messageToBlock(res.GetBlock())
+func getBlockResult(res *access.BlockResponse) (*flow.Block, error) {
+	block, err := messageToBlock(res.GetBlock(), flow.BlockStatus(res.GetBlockStatus()))
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, newMessageToEntityError(entityBlock, err)
+		return nil, newMessageToEntityError(entityBlock, err)
 	}
 
-	return &block, flow.BlockStatus(res.GetBlockStatus()), nil
+	return &block, nil
 }
 
 func (c *BaseClient) GetCollection(

--- a/access/grpc/grpc_test.go
+++ b/access/grpc/grpc_test.go
@@ -90,7 +90,7 @@ func TestClient_GetLatestBlockHeader(t *testing.T) {
 
 		rpc.On("GetLatestBlockHeader", ctx, mock.Anything).Return(response, nil)
 
-		header, err := c.GetLatestBlockHeader(ctx, true)
+		header, _, err := c.GetLatestBlockHeader(ctx, true)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
@@ -100,7 +100,7 @@ func TestClient_GetLatestBlockHeader(t *testing.T) {
 		rpc.On("GetLatestBlockHeader", ctx, mock.Anything).
 			Return(nil, errInternal)
 
-		header, err := c.GetLatestBlockHeader(ctx, true)
+		header, _, err := c.GetLatestBlockHeader(ctx, true)
 		assert.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Nil(t, header)
@@ -124,7 +124,7 @@ func TestClient_GetBlockHeaderByID(t *testing.T) {
 
 		rpc.On("GetBlockHeaderByID", ctx, mock.Anything).Return(response, nil)
 
-		header, err := c.GetBlockHeaderByID(ctx, blockID)
+		header, _, err := c.GetBlockHeaderByID(ctx, blockID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
@@ -136,7 +136,7 @@ func TestClient_GetBlockHeaderByID(t *testing.T) {
 		rpc.On("GetBlockHeaderByID", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		header, err := c.GetBlockHeaderByID(ctx, blockID)
+		header, _, err := c.GetBlockHeaderByID(ctx, blockID)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, header)
@@ -158,7 +158,7 @@ func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 
 		rpc.On("GetBlockHeaderByHeight", ctx, mock.Anything).Return(response, nil)
 
-		header, err := c.GetBlockHeaderByHeight(ctx, 42)
+		header, _, err := c.GetBlockHeaderByHeight(ctx, 42)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedHeader, *header)
@@ -168,7 +168,7 @@ func TestClient_GetBlockHeaderByHeight(t *testing.T) {
 		rpc.On("GetBlockHeaderByHeight", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		header, err := c.GetBlockHeaderByHeight(ctx, 42)
+		header, _, err := c.GetBlockHeaderByHeight(ctx, 42)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, header)
@@ -190,7 +190,7 @@ func TestClient_GetLatestBlock(t *testing.T) {
 
 		rpc.On("GetLatestBlock", ctx, mock.Anything).Return(response, nil)
 
-		block, err := c.GetLatestBlock(ctx, true)
+		block, _, err := c.GetLatestBlock(ctx, true)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
@@ -200,7 +200,7 @@ func TestClient_GetLatestBlock(t *testing.T) {
 		rpc.On("GetLatestBlock", ctx, mock.Anything).
 			Return(nil, errInternal)
 
-		block, err := c.GetLatestBlock(ctx, true)
+		block, _, err := c.GetLatestBlock(ctx, true)
 		assert.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Nil(t, block)
@@ -224,7 +224,7 @@ func TestClient_GetBlockByID(t *testing.T) {
 
 		rpc.On("GetBlockByID", ctx, mock.Anything).Return(response, nil)
 
-		block, err := c.GetBlockByID(ctx, blockID)
+		block, _, err := c.GetBlockByID(ctx, blockID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
@@ -236,7 +236,7 @@ func TestClient_GetBlockByID(t *testing.T) {
 		rpc.On("GetBlockByID", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		block, err := c.GetBlockByID(ctx, blockID)
+		block, _, err := c.GetBlockByID(ctx, blockID)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, block)
@@ -258,7 +258,7 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).Return(response, nil)
 
-		block, err := c.GetBlockByHeight(ctx, 42)
+		block, _, err := c.GetBlockByHeight(ctx, 42)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
@@ -268,7 +268,7 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		block, err := c.GetBlockByHeight(ctx, 42)
+		block, _, err := c.GetBlockByHeight(ctx, 42)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, block)

--- a/access/grpc/grpc_test.go
+++ b/access/grpc/grpc_test.go
@@ -190,7 +190,7 @@ func TestClient_GetLatestBlock(t *testing.T) {
 
 		rpc.On("GetLatestBlock", ctx, mock.Anything).Return(response, nil)
 
-		block, _, err := c.GetLatestBlock(ctx, true)
+		block, err := c.GetLatestBlock(ctx, true)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
@@ -200,7 +200,7 @@ func TestClient_GetLatestBlock(t *testing.T) {
 		rpc.On("GetLatestBlock", ctx, mock.Anything).
 			Return(nil, errInternal)
 
-		block, _, err := c.GetLatestBlock(ctx, true)
+		block, err := c.GetLatestBlock(ctx, true)
 		assert.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.Nil(t, block)
@@ -224,7 +224,7 @@ func TestClient_GetBlockByID(t *testing.T) {
 
 		rpc.On("GetBlockByID", ctx, mock.Anything).Return(response, nil)
 
-		block, _, err := c.GetBlockByID(ctx, blockID)
+		block, err := c.GetBlockByID(ctx, blockID)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
@@ -236,7 +236,7 @@ func TestClient_GetBlockByID(t *testing.T) {
 		rpc.On("GetBlockByID", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		block, _, err := c.GetBlockByID(ctx, blockID)
+		block, err := c.GetBlockByID(ctx, blockID)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, block)
@@ -258,7 +258,7 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).Return(response, nil)
 
-		block, _, err := c.GetBlockByHeight(ctx, 42)
+		block, err := c.GetBlockByHeight(ctx, 42)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedBlock, block)
@@ -268,7 +268,7 @@ func TestClient_GetBlockByHeight(t *testing.T) {
 		rpc.On("GetBlockByHeight", ctx, mock.Anything).
 			Return(nil, errNotFound)
 
-		block, _, err := c.GetBlockByHeight(ctx, 42)
+		block, err := c.GetBlockByHeight(ctx, 42)
 		assert.Error(t, err)
 		assert.Equal(t, codes.NotFound, status.Code(err))
 		assert.Nil(t, block)

--- a/access/http/client.go
+++ b/access/http/client.go
@@ -57,31 +57,31 @@ func (c *Client) GetBlockByID(ctx context.Context, blockID flow.Identifier) (*fl
 	return c.httpClient.GetBlockByID(ctx, blockID)
 }
 
-func (c *Client) GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, error) {
+func (c *Client) GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, flow.BlockStatus, error) {
 	block, err := c.GetLatestBlock(ctx, isSealed)
 	if err != nil {
-		return nil, err
+		return nil, flow.BlockStatusUnknown, err
 	}
 
-	return &block.BlockHeader, nil
+	return &block.BlockHeader, block.Status, nil
 }
 
-func (c *Client) GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, error) {
+func (c *Client) GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, flow.BlockStatus, error) {
 	block, err := c.GetBlockByID(ctx, blockID) // todo optimization: passing the 'select' option to only get the header
 	if err != nil {
-		return nil, err
+		return nil, flow.BlockStatusUnknown, err
 	}
 
-	return &block.BlockHeader, nil
+	return &block.BlockHeader, block.Status, nil
 }
 
-func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, error) {
+func (c *Client) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, flow.BlockStatus, error) {
 	block, err := c.GetBlockByHeight(ctx, height) // todo optimization: passing the 'select' option to only get the header
 	if err != nil {
-		return nil, err
+		return nil, flow.BlockStatusUnknown, err
 	}
 
-	return &block.BlockHeader, nil
+	return &block.BlockHeader, block.Status, nil
 }
 
 func (c *Client) GetLatestBlock(ctx context.Context, isSealed bool) (*flow.Block, error) {

--- a/access/http/client_test.go
+++ b/access/http/client_test.go
@@ -89,7 +89,7 @@ func TestBaseClient_GetBlockByID(t *testing.T) {
 			On(handlerName, mock.Anything, httpBlock.Header.Id).
 			Return(&httpBlock, nil)
 
-		header, err := client.GetBlockHeaderByID(ctx, flow.HexToID(httpBlock.Header.Id))
+		header, _, err := client.GetBlockHeaderByID(ctx, flow.HexToID(httpBlock.Header.Id))
 		assert.NoError(t, err)
 		assert.Equal(t, header, &expectedBlock.BlockHeader)
 	}))
@@ -148,7 +148,7 @@ func TestBaseClient_GetBlockByHeight(t *testing.T) {
 			On(handlerName, mock.Anything, httpBlock.Header.Height, "", "").
 			Return([]*models.Block{&httpBlock}, nil)
 
-		block, err := client.GetBlockHeaderByHeight(ctx, expectedBlock.Height)
+		block, _, err := client.GetBlockHeaderByHeight(ctx, expectedBlock.Height)
 		assert.NoError(t, err)
 		assert.Equal(t, block, &expectedBlock.BlockHeader)
 	}))
@@ -194,7 +194,7 @@ func TestBaseClient_GetLatestBlock(t *testing.T) {
 			On(handlerName, mock.Anything, "final", "", "").
 			Return([]*models.Block{&httpBlock}, nil)
 
-		block, err := client.GetLatestBlockHeader(ctx, false)
+		block, _, err := client.GetLatestBlockHeader(ctx, false)
 		assert.NoError(t, err)
 		assert.Equal(t, block, &expectedBlock.BlockHeader)
 	}))
@@ -208,7 +208,7 @@ func TestBaseClient_GetLatestBlock(t *testing.T) {
 			On(handlerName, mock.Anything, "sealed", "", "").
 			Return([]*models.Block{&httpBlock}, nil)
 
-		block, err := client.GetLatestBlockHeader(ctx, true)
+		block, _, err := client.GetLatestBlockHeader(ctx, true)
 		assert.NoError(t, err)
 		assert.Equal(t, block, &expectedBlock.BlockHeader)
 	}))

--- a/access/http/convert.go
+++ b/access/http/convert.go
@@ -168,6 +168,7 @@ func toBlock(block *models.Block) (*flow.Block, error) {
 	return &flow.Block{
 		BlockHeader:  *toBlockHeader(block.Header),
 		BlockPayload: *payload,
+		Status:       flow.BlockStatusFromString(block.BlockStatus),
 	}, nil
 }
 

--- a/access/http/models/model_block.go
+++ b/access/http/models/model_block.go
@@ -14,4 +14,5 @@ type Block struct {
 	ExecutionResult *ExecutionResult `json:"execution_result,omitempty"`
 	Expandable      *BlockExpandable `json:"_expandable"`
 	Links           *Links           `json:"_links,omitempty"`
+	BlockStatus     string           `json:"block_status"`
 }

--- a/block.go
+++ b/block.go
@@ -49,9 +49,9 @@ const (
 
 func BlockStatusFromString(s string) BlockStatus {
 	switch s {
-	case "BlockStatusFinalized":
+	case "BLOCK_FINALIZED":
 		return BlockStatusFinalized
-	case "BlockStatusSealed":
+	case "BLOCK_SEALED":
 		return BlockStatusSealed
 	default:
 		return BlockStatusUnknown

--- a/block.go
+++ b/block.go
@@ -34,6 +34,18 @@ type BlockHeader struct {
 	Timestamp time.Time
 }
 
+// BlockStatus represents the status of a block.
+type BlockStatus int
+
+const (
+	// BlockStatusUnknown indicates that the block status is not known.
+	BlockStatusUnknown BlockStatus = iota
+	// BlockStatusFinalized is the status of a finalized block.
+	BlockStatusFinalized
+	// BlockStatusSealed is the status of a sealed block.
+	BlockStatusSealed
+)
+
 // BlockPayload is the full contents of a block.
 //
 // A payload contains the collection guarantees and seals for a block.

--- a/block.go
+++ b/block.go
@@ -24,6 +24,7 @@ import "time"
 type Block struct {
 	BlockHeader
 	BlockPayload
+	Status BlockStatus
 }
 
 // BlockHeader is a summary of a full block.
@@ -45,6 +46,17 @@ const (
 	// BlockStatusSealed is the status of a sealed block.
 	BlockStatusSealed
 )
+
+func BlockStatusFromString(s string) BlockStatus {
+	switch s {
+	case "BlockStatusFinalized":
+		return BlockStatusFinalized
+	case "BlockStatusSealed":
+		return BlockStatusSealed
+	default:
+		return BlockStatusUnknown
+	}
+}
 
 // BlockPayload is the full contents of a block.
 //

--- a/examples/cloudkms/main.go
+++ b/examples/cloudkms/main.go
@@ -70,7 +70,7 @@ func GoogleCloudKMSDemo() {
 		panic(err)
 	}
 
-	latestBlock, err := flowClient.GetLatestBlockHeader(ctx, true)
+	latestBlock, _, err := flowClient.GetLatestBlockHeader(ctx, true)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/http_grpc_clients/main.go
+++ b/examples/http_grpc_clients/main.go
@@ -76,7 +76,7 @@ func main() {
 	)
 	examples.Handle(err)
 
-	grpcBlock, err := grpcClient.GetLatestBlockHeader(ctx, true)
+	grpcBlock, _, err := grpcClient.GetLatestBlockHeader(ctx, true)
 	examples.Handle(err)
 
 	fmt.Println("Block ID:", grpcBlock.ID.String())

--- a/examples/verify_events/main.go
+++ b/examples/verify_events/main.go
@@ -43,7 +43,7 @@ func VerifyEventsDemo() {
 	flowClient, err := http.NewClient(http.EmulatorHost)
 	examples.Handle(err)
 
-	latestBlockHeader, err := flowClient.GetLatestBlockHeader(ctx, true)
+	latestBlockHeader, _, err := flowClient.GetLatestBlockHeader(ctx, true)
 	examples.Handle(err)
 
 	block, err := flowClient.GetBlockByID(ctx, latestBlockHeader.ID)

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/ethereum/go-ethereum v1.9.13
 	github.com/onflow/cadence v0.37.0
 	github.com/onflow/flow-go/crypto v0.24.7
-	github.com/onflow/flow/protobuf/go/flow v0.3.1
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221202093946-932d1c70e288
 	github.com/onflow/sdks v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/api v0.70.0
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf
-	google.golang.org/grpc v1.44.0
-	google.golang.org/protobuf v1.27.1
+	google.golang.org/grpc v1.51.0
+	google.golang.org/protobuf v1.28.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,8 @@ github.com/onflow/cadence v0.37.0 h1:eRdHzkkYtRKu6vNMkX0rGXca63zL4X4h9lqsvnDVD9c
 github.com/onflow/cadence v0.37.0/go.mod h1:SpfjNhPsJxGIHbOthE9JD/e8JFaFY73joYLPsov+PY4=
 github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
-github.com/onflow/flow/protobuf/go/flow v0.3.1 h1:4I8ykG6naR3n8Or6eXrZDaGVaoztb3gP2KJ6XKyDufg=
-github.com/onflow/flow/protobuf/go/flow v0.3.1/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221202093946-932d1c70e288 h1:haWv3D5loiH+zcOoWEvDXtWQvXt5U8PLliQjwhv9sfw=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221202093946-932d1c70e288/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=
 github.com/onflow/sdks v0.5.0/go.mod h1:F0dj0EyHC55kknLkeD10js4mo14yTdMotnWMslPirrU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -762,8 +762,9 @@ google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.51.0 h1:E1eGv1FTqoLIdnBCZufiSHgKjlqG6fKFf6pPWtMTh8U=
+google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -777,8 +778,9 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Description

Required for https://github.com/onflow/flow-cli/issues/576

Tried to change signatures minimal;

```
GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flow.BlockHeader, flow.BlockStatus, error)
GetBlockHeaderByID(ctx context.Context, blockID flow.Identifier) (*flow.BlockHeader, flow.BlockStatus, error)
GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.BlockHeader, flow.BlockStatus, error)
```

also added `Status` field to `Block`

```
flow.Block{
		BlockHeader:  *header,
		BlockPayload: *payload,
		Status:       status,
}
```

another approach can be adding also `Status` field to `BlockHeader` and keep exported signatures same. 

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
