### PR TITLE
Enable CI for versioned branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - 'v**'
   pull_request:
     branches:
       - master
+      - 'v**'
 
 jobs:
   test:


### PR DESCRIPTION
## Description

We might need to maintain versioned branches. e.g: https://github.com/onflow/flow-go-sdk/pull/425
So enabling CI for those branches as well.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
