### PR TITLE
Add support for CollectionID in TransactionResult

### DIFF
--- a/access/grpc/convert.go
+++ b/access/grpc/convert.go
@@ -502,6 +502,7 @@ func transactionResultToMessage(result flow.TransactionResult) (*access.Transact
 		BlockId:       identifierToMessage(result.BlockID),
 		BlockHeight:   result.BlockHeight,
 		TransactionId: identifierToMessage(result.TransactionID),
+		CollectionId:  identifierToMessage(result.CollectionID),
 	}, nil
 }
 
@@ -537,5 +538,6 @@ func messageToTransactionResult(m *access.TransactionResultResponse, options []j
 		BlockID:       flow.BytesToID(m.GetBlockId()),
 		BlockHeight:   m.GetBlockHeight(),
 		TransactionID: flow.BytesToID(m.GetTransactionId()),
+		CollectionID:  flow.BytesToID(m.GetCollectionId()),
 	}, nil
 }

--- a/test/entities.go
+++ b/test/entities.go
@@ -409,28 +409,27 @@ func (g *Transactions) NewUnsigned() *flow.Transaction {
 
 type TransactionResults struct {
 	events *Events
+	ids    *Identifiers
 }
 
 func TransactionResultGenerator() *TransactionResults {
 	return &TransactionResults{
 		events: EventGenerator(),
+		ids:    IdentifierGenerator(),
 	}
 }
 
 func (g *TransactionResults) New() flow.TransactionResult {
-	eventA := g.events.New()
-	eventB := g.events.New()
-	blockID := newIdentifier(1)
-	blockHeight := uint64(42)
-
 	return flow.TransactionResult{
 		Status: flow.TransactionStatusSealed,
 		Error:  errors.New("transaction execution error"),
 		Events: []flow.Event{
-			eventA,
-			eventB,
+			g.events.New(),
+			g.events.New(),
 		},
-		BlockID:     blockID,
-		BlockHeight: blockHeight,
+		BlockID:       g.ids.New(),
+		BlockHeight:   uint64(42),
+		TransactionID: g.ids.New(),
+		CollectionID:  g.ids.New(),
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -615,6 +615,7 @@ type TransactionResult struct {
 	BlockID       Identifier
 	BlockHeight   uint64
 	TransactionID Identifier
+	CollectionID  Identifier
 }
 
 // TransactionStatus represents the status of a transaction.


### PR DESCRIPTION
## Description

Transaction results include a `CollectionID` field which indicates which collection the transaction was included in. See protobuf:
https://github.com/onflow/flow/blob/3f149a861ec42550915e63d188e4328d5ee38445/protobuf/flow/access/access.proto#L249-L259

This PR adds the `CollectionID` field to the response for endpoints returning `TransactionResult` objects.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
