### PR TITLE
Use CCF encoding when requesting events from AccessAPI

### DIFF
--- a/access/grpc/convert.go
+++ b/access/grpc/convert.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/ccf"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow/protobuf/go/flow/access"
 	"github.com/onflow/flow/protobuf/go/flow/entities"
@@ -213,6 +214,15 @@ func cadenceValuesToMessages(values []cadence.Value) ([][]byte, error) {
 }
 
 func messageToCadenceValue(m []byte, options []jsoncdc.Option) (cadence.Value, error) {
+	if ccf.HasMsgPrefix(m) {
+		// modern Access nodes support encoding events in CCF format
+		v, err := ccf.Decode(nil, m)
+		if err == nil {
+			return v, nil
+		}
+		return v, nil
+	}
+
 	v, err := jsoncdc.Decode(nil, m, options...)
 	if err != nil {
 		return nil, fmt.Errorf("convert: %w", err)

--- a/access/grpc/convert.go
+++ b/access/grpc/convert.go
@@ -195,7 +195,7 @@ func messageToBlockHeader(m *entities.BlockHeader) (flow.BlockHeader, error) {
 func cadenceValueToMessage(value cadence.Value) ([]byte, error) {
 	b, err := jsoncdc.Encode(value)
 	if err != nil {
-		return nil, fmt.Errorf("convert: %w", err)
+		return nil, fmt.Errorf("jsoncdc convert: %w", err)
 	}
 
 	return b, nil
@@ -206,7 +206,7 @@ func cadenceValuesToMessages(values []cadence.Value) ([][]byte, error) {
 	for i, val := range values {
 		msg, err := cadenceValueToMessage(val)
 		if err != nil {
-			return nil, fmt.Errorf("convert: %w", err)
+			return nil, err
 		}
 		msgs[i] = msg
 	}
@@ -217,15 +217,15 @@ func messageToCadenceValue(m []byte, options []jsoncdc.Option) (cadence.Value, e
 	if ccf.HasMsgPrefix(m) {
 		// modern Access nodes support encoding events in CCF format
 		v, err := ccf.Decode(nil, m)
-		if err == nil {
-			return v, nil
+		if err != nil {
+			return nil, fmt.Errorf("ccf convert: %w", err)
 		}
 		return v, nil
 	}
 
 	v, err := jsoncdc.Decode(nil, m, options...)
 	if err != nil {
-		return nil, fmt.Errorf("convert: %w", err)
+		return nil, fmt.Errorf("jsoncdc convert: %w", err)
 	}
 
 	return v, nil

--- a/access/grpc/convert_test.go
+++ b/access/grpc/convert_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/ccf"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -124,6 +126,17 @@ func TestConvert_CadenceValue(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, value)
 	})
+
+	t.Run("CCF encoded value", func(t *testing.T) {
+		eventA := test.EventGenerator().
+			WithEncoding(entities.EventEncodingVersion_CCF_V0).
+			New()
+
+		valueB, err := messageToCadenceValue(eventA.Payload, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, eventA.Value, valueB)
+	})
 }
 
 func TestConvert_Collection(t *testing.T) {
@@ -194,19 +207,45 @@ func TestConvert_BlockSeals(t *testing.T) {
 }
 
 func TestConvert_Event(t *testing.T) {
-	eventA := test.EventGenerator().New()
 
-	msg, err := eventToMessage(eventA)
-	require.NoError(t, err)
+	t.Run("JSON-CDC encoded payload", func(t *testing.T) {
+		eventA := test.EventGenerator().
+			WithEncoding(entities.EventEncodingVersion_JSON_CDC_V0).
+			New()
+		msg, err := eventToMessage(eventA)
+		require.NoError(t, err)
 
-	eventB, err := messageToEvent(msg, nil)
-	require.NoError(t, err)
+		eventB, err := messageToEvent(msg, nil)
+		require.NoError(t, err)
 
-	// Force evaluation of type ID, which is cached in type.
-	// Necessary for equality check below
-	_ = eventB.Value.Type().ID()
+		// Force evaluation of type ID, which is cached in type.
+		// Necessary for equality check below
+		_ = eventB.Value.Type().ID()
 
-	assert.Equal(t, eventA, eventB)
+		assert.Equal(t, eventA, eventB)
+	})
+
+	t.Run("CCF encoded payload", func(t *testing.T) {
+		eventA := test.EventGenerator().
+			WithEncoding(entities.EventEncodingVersion_CCF_V0).
+			New()
+
+		msg, err := eventToMessage(eventA)
+		require.NoError(t, err)
+
+		// explicitly re-encode the payload using CCF
+		msg.Payload, err = ccf.Encode(eventA.Value)
+		require.NoError(t, err)
+
+		eventB, err := messageToEvent(msg, nil)
+		require.NoError(t, err)
+
+		// Force evaluation of type ID, which is cached in type.
+		// Necessary for equality check below
+		_ = eventB.Value.Type().ID()
+
+		assert.Equal(t, eventA, eventB)
+	})
 }
 
 func TestConvert_Identifier(t *testing.T) {

--- a/access/grpc/convert_test.go
+++ b/access/grpc/convert_test.go
@@ -128,14 +128,15 @@ func TestConvert_CadenceValue(t *testing.T) {
 	})
 
 	t.Run("CCF encoded value", func(t *testing.T) {
-		eventA := test.EventGenerator().
-			WithEncoding(entities.EventEncodingVersion_CCF_V0).
-			New()
+		valueA := cadence.NewInt(42)
 
-		valueB, err := messageToCadenceValue(eventA.Payload, nil)
+		msg, err := ccf.Encode(valueA)
 		require.NoError(t, err)
 
-		assert.Equal(t, eventA.Value, valueB)
+		valueB, err := messageToCadenceValue(msg, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, valueA, valueB)
 	})
 }
 

--- a/access/grpc/grpc.go
+++ b/access/grpc/grpc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow/protobuf/go/flow/access"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
 
 	"github.com/onflow/flow-go-sdk"
 )
@@ -315,7 +316,8 @@ func (c *BaseClient) GetTransactionResult(
 	opts ...grpc.CallOption,
 ) (*flow.TransactionResult, error) {
 	req := &access.GetTransactionRequest{
-		Id: txID.Bytes(),
+		Id:                   txID.Bytes(),
+		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
 	}
 
 	res, err := c.rpcClient.GetTransactionResult(ctx, req, opts...)
@@ -339,8 +341,9 @@ func (c *BaseClient) GetTransactionResultByIndex(
 ) (*flow.TransactionResult, error) {
 
 	req := &access.GetTransactionByIndexRequest{
-		BlockId: blockID.Bytes(),
-		Index:   index,
+		BlockId:              blockID.Bytes(),
+		Index:                index,
+		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
 	}
 
 	res, err := c.rpcClient.GetTransactionResultByIndex(ctx, req, opts...)
@@ -362,7 +365,8 @@ func (c *BaseClient) GetTransactionResultsByBlockID(
 ) ([]*flow.TransactionResult, error) {
 
 	req := &access.GetTransactionsByBlockIDRequest{
-		BlockId: blockID.Bytes(),
+		BlockId:              blockID.Bytes(),
+		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
 	}
 
 	res, err := c.rpcClient.GetTransactionResultsByBlockID(ctx, req, opts...)
@@ -537,9 +541,10 @@ func (c *BaseClient) GetEventsForHeightRange(
 	opts ...grpc.CallOption,
 ) ([]flow.BlockEvents, error) {
 	req := &access.GetEventsForHeightRangeRequest{
-		Type:        query.Type,
-		StartHeight: query.StartHeight,
-		EndHeight:   query.EndHeight,
+		Type:                 query.Type,
+		StartHeight:          query.StartHeight,
+		EndHeight:            query.EndHeight,
+		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
 	}
 
 	res, err := c.rpcClient.GetEventsForHeightRange(ctx, req, opts...)
@@ -557,8 +562,9 @@ func (c *BaseClient) GetEventsForBlockIDs(
 	opts ...grpc.CallOption,
 ) ([]flow.BlockEvents, error) {
 	req := &access.GetEventsForBlockIDsRequest{
-		Type:     eventType,
-		BlockIds: identifiersToMessages(blockIDs),
+		Type:                 eventType,
+		BlockIds:             identifiersToMessages(blockIDs),
+		EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
 	}
 
 	res, err := c.rpcClient.GetEventsForBlockIDs(ctx, req, opts...)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onflow/cadence v0.42.1
 	github.com/onflow/crypto v0.24.9
 	github.com/onflow/flow-cli/flowkit v1.4.3
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231018182244-e72527c55c63
 	github.com/onflow/sdks v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/bits-and-blooms/bitset v1.5.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/btcsuite/btcd/btcec/v2 v2.2.1 h1:xP60mv8fvp+0khmrN0zTdPC3cNm24rfeE6lh2R/Yv3E=
 github.com/btcsuite/btcd/btcec/v2 v2.2.1/go.mod h1:9/CSmJxmuvqzX9Wh2fXMWToLOHhPd11lSPuIupwTkI8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -173,7 +172,6 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3 h1:yk9/cqRKtT9wXZSsRH9aurXEpJX+U6FLtpYTdC3R06k=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -224,8 +222,6 @@ github.com/onflow/crypto v0.24.9 h1:jYP1qdwid0qCineFzBFlxBchg710A7RuSWpTqxaOdog=
 github.com/onflow/crypto v0.24.9/go.mod h1:J/V7IEVaqjDajvF8K0B/SJPJDgAOP2G+LVLeb0hgmbg=
 github.com/onflow/flow-cli/flowkit v1.4.3 h1:fwG20ZfVKAP2geSzImZ+LL1NhVSMLQfko5ZvicTkZv8=
 github.com/onflow/flow-cli/flowkit v1.4.3/go.mod h1:AQWWUCq3UDXIEI1dG2MADyHi5ZeGE5pIvS5Fh0k/ITU=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce h1:YQKijiQaq8SF1ayNqp3VVcwbBGXSnuHNHq4GQmVGybE=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231018182244-e72527c55c63 h1:SX8OhYbyKBExhy4qEDR/Hw6MVTBTzlDb8LfCHfFyte4=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231018182244-e72527c55c63/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,7 @@ github.com/bits-and-blooms/bitset v1.5.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/btcsuite/btcd/btcec/v2 v2.2.1 h1:xP60mv8fvp+0khmrN0zTdPC3cNm24rfeE6lh2R/Yv3E=
 github.com/btcsuite/btcd/btcec/v2 v2.2.1/go.mod h1:9/CSmJxmuvqzX9Wh2fXMWToLOHhPd11lSPuIupwTkI8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -172,6 +173,7 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3 h1:yk9/cqRKtT9wXZSsRH9aurXEpJX+U6FLtpYTdC3R06k=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -224,6 +226,8 @@ github.com/onflow/flow-cli/flowkit v1.4.3 h1:fwG20ZfVKAP2geSzImZ+LL1NhVSMLQfko5Z
 github.com/onflow/flow-cli/flowkit v1.4.3/go.mod h1:AQWWUCq3UDXIEI1dG2MADyHi5ZeGE5pIvS5Fh0k/ITU=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce h1:YQKijiQaq8SF1ayNqp3VVcwbBGXSnuHNHq4GQmVGybE=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231018182244-e72527c55c63 h1:SX8OhYbyKBExhy4qEDR/Hw6MVTBTzlDb8LfCHfFyte4=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231018182244-e72527c55c63/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=
 github.com/onflow/sdks v0.5.0/go.mod h1:F0dj0EyHC55kknLkeD10js4mo14yTdMotnWMslPirrU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/test/entities.go
+++ b/test/entities.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/ccf"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
 
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -239,8 +241,9 @@ func (g *BlockSeals) New() *flow.BlockSeal {
 }
 
 type Events struct {
-	count int
-	ids   *Identifiers
+	count    int
+	ids      *Identifiers
+	encoding entities.EventEncodingVersion
 }
 
 func EventGenerator() *Events {
@@ -248,6 +251,18 @@ func EventGenerator() *Events {
 		count: 1,
 		ids:   IdentifierGenerator(),
 	}
+}
+
+func (g *Events) WithEncoding(encoding entities.EventEncodingVersion) *Events {
+	switch encoding {
+	case entities.EventEncodingVersion_CCF_V0:
+		g.encoding = encoding
+	case entities.EventEncodingVersion_JSON_CDC_V0:
+		g.encoding = encoding
+	default:
+		panic(fmt.Errorf("unsupported event encoding: %v", encoding))
+	}
+	return g
 }
 
 func (g *Events) New() flow.Event {
@@ -280,7 +295,14 @@ func (g *Events) New() flow.Event {
 
 	typeID := location.TypeID(nil, identifier)
 
-	payload, err := jsoncdc.Encode(testEvent)
+	var payload []byte
+	var err error
+	if g.encoding == entities.EventEncodingVersion_CCF_V0 {
+		payload, err = ccf.Encode(testEvent)
+	} else {
+		payload, err = jsoncdc.Encode(testEvent)
+	}
+
 	if err != nil {
 		panic(fmt.Errorf("cannot encode test event: %w", err))
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go-sdk/issues/500

## Description

The AccessAPI recently added support for specifying the encoding for events returned in the request. CCF encoding is significantly more compact and includes additional information that can't be included in JSON-CDC format.

This PR updates all gRPC calls to endpoints that support CCF encoding to use the new format, and handles conversion to the original cadence object. The change should be transparent to the caller, except that less data is transported over the web.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
