### PR TITLE
add convenience method for getting prefixed address as string

### DIFF
--- a/address.go
+++ b/address.go
@@ -159,6 +159,11 @@ func (a Address) Hex() string {
 	return hex.EncodeToString(a.Bytes())
 }
 
+// Hex returns the address as hex string with "0x" prefix.
+func (a Address) HexWithPrefix() string {
+	return fmt.Sprintf("0x%s", a.Hex())
+}
+
 // String returns the string representation of the address.
 func (a Address) String() string {
 	return a.Hex()

--- a/address_test.go
+++ b/address_test.go
@@ -64,7 +64,7 @@ func TestHexWithPrefix(t *testing.T) {
 	for _, test := range []testCase{
 		{"0x0000000000000123", []byte{0x1, 0x23}},
 		{"0x0000000000000001", []byte{0x1}},
-		{"0x0000000000000001", []byte{0x1}},
+		{"0xe03daebed8ca0615", []byte{0xe0, 0x3d, 0xae, 0xbe, 0xd8, 0xca, 0x06, 0x15}},
 	} {
 
 		addr := BytesToAddress(test.value)

--- a/address_test.go
+++ b/address_test.go
@@ -54,6 +54,26 @@ func TestHexToAddress(t *testing.T) {
 	}
 }
 
+func TestHexWithPrefix(t *testing.T) {
+
+	type testCase struct {
+		literal string
+		value   []byte
+	}
+
+	for _, test := range []testCase{
+		{"0x0000000000000123", []byte{0x1, 0x23}},
+		{"0x0000000000000001", []byte{0x1}},
+		{"0x0000000000000001", []byte{0x1}},
+	} {
+
+		addr := BytesToAddress(test.value)
+		expected := addr.HexWithPrefix()
+
+		assert.Equal(t, expected, test.literal)
+		assert.Equal(t, expected, test.literal)
+	}
+}
 func TestAddressJSON(t *testing.T) {
 	addr := ServiceAddress(Mainnet)
 	data, err := json.Marshal(addressWrapper{Address: addr})


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go-sdk/issues/553

## Description

Add HexWithPrefix method so user's don't have to prepend "0x" to addresses and added unit tests.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
