### PR TITLE
Update to Cadence v1.0.0-M9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.25.5
 	github.com/aws/aws-sdk-go-v2/service/kms v1.26.3
 	github.com/ethereum/go-ethereum v1.13.5
-	github.com/onflow/cadence v1.0.0-M8
+	github.com/onflow/cadence v1.0.0-M9
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2
 	github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M8 h1:ioQ7TyhpsIaImAC7Xn2r8kIgIBdimvyuWeKlGfRxWB8=
-github.com/onflow/cadence v1.0.0-M8/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
+github.com/onflow/cadence v1.0.0-M9 h1:hYqh6iok2X+QEyAlvoEY1k57EV7Yt8+Iz5+lGvjey3o=
+github.com/onflow/cadence v1.0.0-M9/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2 h1:qZjl4wSTG/E9znEjkHF0nNaEdlBLJoOEAtr7xUsTNqc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-M9](https://github.com/onflow/cadence/releases/tag/v1.0.0-M9)

