### PR TITLE
Upgrade `onflow/crypto` and clarify build details

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ To start using the SDK, install Go 1.13 or above and run go get:
 go get github.com/onflow/flow-go-sdk
 ```
 
-Building and running Go commands with the SDK require enabling cgo : `CGO_ENABLED=1`
+Building and testing Go commands with the SDK require enabling cgo `CGO_ENABLED=1` because of the underlying
+cryptography library. Refer to the [crypto repository build](https://github.com/onflow/crypto?tab=readme-ov-file#build) for more details.
 
 ## Generating Keys
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ To start using the SDK, install Go 1.13 or above and run go get:
 go get github.com/onflow/flow-go-sdk
 ```
 
-Building and testing Go commands with the SDK require enabling cgo `CGO_ENABLED=1` because of the underlying
-cryptography library. Refer to the [crypto repository build](https://github.com/onflow/crypto?tab=readme-ov-file#build) for more details.
+Building and testing Go commands with the SDK require enabling cgo `CGO_ENABLED=1` because of the underlying cryptography library.
+Refer to the [crypto repository build](https://github.com/onflow/crypto?tab=readme-ov-file#build) for more details.
+
+Note that it is possible to build with cgo disabled `CGO_ENABLED=0`, but this requires confirming the choice by using the Go build tag `no-cgo`. This would disable the crypto BLS signature features of the SDK.
+Any call of a BLS tool would result in a panic.
 
 ## Generating Keys
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.26.3
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/onflow/cadence v1.0.0-preview.18
-	github.com/onflow/crypto v0.25.0
+	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2
 	github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 h1:jJLDswfAVB0bHCu1
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-preview.18 h1:1gN+suBexuu1gZz0JjWDC9dcGBI/GIMP8R0Tyou9mzA=
 github.com/onflow/cadence v1.0.0-preview.18/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
-github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
-github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
+github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
+github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2 h1:qZjl4wSTG/E9znEjkHF0nNaEdlBLJoOEAtr7xUsTNqc=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba h1:rIehuhO6bj4FkwE4VzwEjX7MoAlOhUJENBJLqDqVxAo=


### PR DESCRIPTION
- upgrade `onflow/crypto`
- clarify build constraints related to https://github.com/onflow/crypto when using the module. This also addresses https://github.com/onflow/crypto/issues/7.