### PR TITLE
Fix panic when encoding transaction with empty arguments (`release/v0`)

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -160,7 +160,7 @@ func mustRLPEncode(v interface{}) []byte {
 	// Note(sideninja): This is a temporary workaround until cadence defines canonical format addressing the issue https://github.com/onflow/flow-go-sdk/issues/286
 	if tx, ok := v.(payloadCanonicalForm); ok {
 		for _, arg := range tx.Arguments {
-			if arg[len(arg)-1] == byte(10) {
+			if len(arg) > 0 && arg[len(arg)-1] == byte(10) {
 				arg = arg[:len(tx.Arguments)-1]
 			}
 		}

--- a/transaction.go
+++ b/transaction.go
@@ -380,7 +380,7 @@ func (t *Transaction) payloadCanonicalForm() payloadCanonicalForm {
 
 	// note(sideninja): This is a temporary workaround until cadence defines canonical format addressing the issue https://github.com/onflow/flow-go-sdk/issues/286
 	for i, arg := range t.Arguments {
-		if arg[len(arg)-1] == byte(10) { // extra new line character
+		if len(arg) > 0 && arg[len(arg)-1] == byte(10) { // extra new line character
 			t.Arguments[i] = arg[:len(arg)-1]
 		}
 	}


### PR DESCRIPTION
Closes: #631 

## Description

Fixes panic if transaction arguments are empty (`release/v0`) branch

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
