### PR TITLE
Make event encoding configurable over grpc

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -23,4 +23,12 @@ import (
 	// as it registers the type ID decoder for the Flow types,
 	// e.g. `flow.AccountCreated`
 	_ "github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
+)
+
+type EventEncodingVersion = entities.EventEncodingVersion
+
+const (
+	EventEncodingVersionCCF     = entities.EventEncodingVersion_CCF_V0
+	EventEncodingVersionJSONCDC = entities.EventEncodingVersion_JSON_CDC_V0
 )

--- a/test/entities.go
+++ b/test/entities.go
@@ -255,9 +255,9 @@ func EventGenerator() *Events {
 
 func (g *Events) WithEncoding(encoding entities.EventEncodingVersion) *Events {
 	switch encoding {
-	case entities.EventEncodingVersion_CCF_V0:
+	case flow.EventEncodingVersionCCF:
 		g.encoding = encoding
-	case entities.EventEncodingVersion_JSON_CDC_V0:
+	case flow.EventEncodingVersionJSONCDC:
 		g.encoding = encoding
 	default:
 		panic(fmt.Errorf("unsupported event encoding: %v", encoding))
@@ -297,7 +297,7 @@ func (g *Events) New() flow.Event {
 
 	var payload []byte
 	var err error
-	if g.encoding == entities.EventEncodingVersion_CCF_V0 {
+	if g.encoding == flow.EventEncodingVersionCCF {
 		payload, err = ccf.Encode(testEvent)
 	} else {
 		payload, err = jsoncdc.Encode(testEvent)
@@ -490,7 +490,7 @@ func ChunkExecutionDataGenerator() *ChunkExecutionDatas {
 	return &ChunkExecutionDatas{
 		ids:         IdentifierGenerator(),
 		txs:         TransactionGenerator(),
-		events:      EventGenerator().WithEncoding(entities.EventEncodingVersion_CCF_V0),
+		events:      EventGenerator().WithEncoding(flow.EventEncodingVersionCCF),
 		trieUpdates: TrieUpdateGenerator(),
 		results:     LightTransactionResultGenerator(),
 	}


### PR DESCRIPTION
Closes: #666 

## Description

Currently, event encoding is hard coded to use CCF. This was added to switch to the smaller size payloads. However, it does not support backwards compatibility mode needed by some clients during the Cadence 1.0 transition.

This PR updates the grpc client code to allow setting the event encoding for the client. During the transition, users can switch to use JSONCDC.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
