### PR TITLE
Add method to get execution data client

### DIFF
--- a/access/grpc/client.go
+++ b/access/grpc/client.go
@@ -117,6 +117,10 @@ func (c *Client) RPCClient() RPCClient {
 	return c.grpc.RPCClient()
 }
 
+func (c *Client) ExecutionDataRPCClient() ExecutionDataRPCClient {
+	return c.grpc.ExecutionDataRPCClient()
+}
+
 func (c *Client) Ping(ctx context.Context) error {
 	return c.grpc.Ping(ctx)
 }

--- a/access/grpc/grpc.go
+++ b/access/grpc/grpc.go
@@ -134,6 +134,10 @@ func (c *BaseClient) RPCClient() RPCClient {
 	return c.rpcClient
 }
 
+func (c *BaseClient) ExecutionDataRPCClient() ExecutionDataRPCClient {
+	return c.executionDataClient
+}
+
 // Close closes the client connection.
 func (c *BaseClient) Close() error {
 	return c.close()


### PR DESCRIPTION
Closes: #???

## Description

Currently, there's no way to get the execution data client used by the SDK client. This is sometimes useful when the SDK is not fully up to date with the access API. 

Adding a `ExecutionDataRPCClient()` method to return the raw client

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
