### PR TITLE
[Access] Fix SendAndSubscribeTransactionStatuses and example

### DIFF
--- a/access/grpc/grpc.go
+++ b/access/grpc/grpc.go
@@ -1284,7 +1284,7 @@ func (c *BaseClient) SendAndSubscribeTransactionStatuses(
 		defer close(txStatusChan)
 		defer close(errChan)
 
-		messageIndex := uint64(0)
+		messageIndex := uint64(1)
 
 		for {
 			txResultsResponse, err := subscribeClient.Recv()

--- a/access/grpc/grpc_test.go
+++ b/access/grpc/grpc_test.go
@@ -2539,7 +2539,7 @@ func TestClient_SendAndSubscribeTransactionStatuses(t *testing.T) {
 		var resTransactionResults []*access.SendAndSubscribeTransactionStatusesResponse
 		results := test.TransactionResultGenerator(encodingVersion)
 
-		for i := uint64(0); i < count; i++ {
+		for i := uint64(1); i <= count; i++ {
 			expectedResult := results.New()
 			transactionResult, _ := convert.TransactionResultToMessage(expectedResult, encodingVersion)
 
@@ -2573,7 +2573,7 @@ func TestClient_SendAndSubscribeTransactionStatuses(t *testing.T) {
 		wg.Add(1)
 		go assertNoErrors(t, errCh, wg.Done)
 
-		expectedCounter := uint64(0)
+		expectedCounter := uint64(1)
 
 		for i := uint64(0); i < responseCount; i++ {
 			actualTxResult := <-txResultCh
@@ -2608,7 +2608,7 @@ func TestClient_SendAndSubscribeTransactionStatuses(t *testing.T) {
 		wg.Add(1)
 		go assertNoErrors(t, errCh, wg.Done)
 
-		expectedCounter := uint64(0)
+		expectedCounter := uint64(1)
 		for i := uint64(0); i < responseCount; i++ {
 			actualTxResult := <-txResultCh
 			expectedTxResult, err := convert.MessageToTransactionResult(stream.responses[i].GetTransactionResults(), DefaultClientOptions().jsonOptions)

--- a/examples/send_and_subscribe_transaction_statuses/main.go
+++ b/examples/send_and_subscribe_transaction_statuses/main.go
@@ -21,12 +21,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/onflow/flow-go-sdk/crypto"
 	"log"
 
-	"github.com/onflow/flow-go-sdk/access/grpc"
-
 	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/access/grpc"
+	"github.com/onflow/flow-go-sdk/crypto"
 	"github.com/onflow/flow-go-sdk/examples"
 )
 

--- a/examples/send_and_subscribe_transaction_statuses/main.go
+++ b/examples/send_and_subscribe_transaction_statuses/main.go
@@ -35,7 +35,7 @@ func main() {
 
 func demo() {
 	ctx := context.Background()
-	flowClient, err := grpc.NewClient("access.testnet.nodes.onflow.org:9000")
+	flowClient, err := grpc.NewClient(grpc.TestnetHost)
 	examples.Handle(err)
 
 	signerIndex := uint32(0)


### PR DESCRIPTION
Closes: [#6604](https://github.com/onflow/flow-go/issues/6604)

## Description

* Implements an example of `SendAndSubscribeTransactionStatuses` on the testnet, as the emulator does not support subscriptions.  
* The `messageIndex` value has been fixed, as it should always start at 1.