### PR TITLE
Switch to using latest finalized block as transaction reference block

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -140,7 +140,11 @@ func RandomAccount(flowClient access.Client) (flow.Address, *flow.AccountKey, cr
 }
 
 func GetReferenceBlockId(flowClient access.Client) flow.Identifier {
-	block, err := flowClient.GetLatestBlock(context.Background(), true)
+	// We use the latest finalized block as the reference block ID.
+	// This is the block that has been finalized and is guaranteed to be included in the chain.
+	// It is the best choice for a reference block ID, as block sealing lags behind finalization
+	// and using a sealed block may cause the reference to fall outside the expiration window.
+	block, err := flowClient.GetLatestBlock(context.Background(), false)
 	Handle(err)
 
 	return block.ID

--- a/transaction.go
+++ b/transaction.go
@@ -178,6 +178,11 @@ func (t *Transaction) Argument(i int, options ...jsoncdc.Option) (cadence.Value,
 //
 // For example, if a transaction references a block with height of X and the network limit is 10,
 // a block with height X+10 is the last block that is allowed to include this transaction.
+//
+// It is recommended to use the latest finalized block as the reference block ID.
+// Transaction expiry is determined by the height difference between the reference block
+// and the block that includes the transaction.  Block sealing lags behind finalization and
+// using the latest sealed block may cause the reference to fall outside the expiration window.
 func (t *Transaction) SetReferenceBlockID(blockID Identifier) *Transaction {
 	t.ReferenceBlockID = blockID
 	return t


### PR DESCRIPTION
Closes: #873 

## Description

Switch to using the latest finalize block as the transaction reference block and update comments accordingly.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
