### PR TITLE
Improve passkeys integration, to allow adding signatures with extension data

### DIFF
--- a/access/grpc/convert/convert.go
+++ b/access/grpc/convert/convert.go
@@ -861,11 +861,21 @@ func MessageToTransaction(m *entities.Transaction) (flow.Transaction, error) {
 
 	for _, sig := range m.GetPayloadSignatures() {
 		addr := flow.BytesToAddress(sig.GetAddress())
+		// Have to support legacy implementation for now, so check for extension data here before adding the signature
+		if len(sig.GetExtensionData()) > 0 {
+			t.AddPayloadSignatureWithExtensionData(addr, sig.GetKeyId(), sig.GetSignature(), sig.GetExtensionData())
+			continue
+		}
 		t.AddPayloadSignature(addr, sig.GetKeyId(), sig.GetSignature())
 	}
 
 	for _, sig := range m.GetEnvelopeSignatures() {
 		addr := flow.BytesToAddress(sig.GetAddress())
+		// Have to support legacy implementation for now, so check for extension data here before adding the signature
+		if len(sig.GetExtensionData()) > 0 {
+			t.AddEnvelopeSignatureWithExtensionData(addr, sig.GetKeyId(), sig.GetSignature(), sig.GetExtensionData())
+			continue
+		}
 		t.AddEnvelopeSignature(addr, sig.GetKeyId(), sig.GetSignature())
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -358,9 +358,30 @@ func (t *Transaction) AddPayloadSignature(address Address, keyIndex uint32, sig 
 	return t
 }
 
+// AddPayloadSignatureWithExtensionData adds a payload signature to the transaction for the given address and key index. Includes extension data.
+func (t *Transaction) AddPayloadSignatureWithExtensionData(address Address, keyIndex uint32, sig []byte, extensionData []byte) *Transaction {
+	// to properly support extension data, the parent function must pass in the extension data
+	s := t.createSignature(address, keyIndex, sig, extensionData)
+
+	t.PayloadSignatures = append(t.PayloadSignatures, s)
+	sort.Slice(t.PayloadSignatures, compareSignatures(t.PayloadSignatures))
+	t.refreshSignerIndex()
+	return t
+}
+
 // AddEnvelopeSignature adds an envelope signature to the transaction for the given address and key index.
 func (t *Transaction) AddEnvelopeSignature(address Address, keyIndex uint32, sig []byte) *Transaction {
 	s := t.createSignature(address, keyIndex, sig, nil)
+
+	t.EnvelopeSignatures = append(t.EnvelopeSignatures, s)
+	sort.Slice(t.EnvelopeSignatures, compareSignatures(t.EnvelopeSignatures))
+	t.refreshSignerIndex()
+	return t
+}
+
+// AddEnvelopeSignatureWithExtensionData adds an envelope signature to the transaction for the given address and key index. Includes extension data.
+func (t *Transaction) AddEnvelopeSignatureWithExtensionData(address Address, keyIndex uint32, sig []byte, extensionData []byte) *Transaction {
+	s := t.createSignature(address, keyIndex, sig, extensionData)
 
 	t.EnvelopeSignatures = append(t.EnvelopeSignatures, s)
 	sort.Slice(t.EnvelopeSignatures, compareSignatures(t.EnvelopeSignatures))


### PR DESCRIPTION
Closes: #???

## Description

Adds 2 new functions to allow adding signatures with extension data.

Also uses these functions in the grpc convert message step

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
