### PR TITLE
Update to Cadence v1.9.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5
 	github.com/ethereum/go-ethereum v1.16.7
-	github.com/onflow/cadence v1.9.5
+	github.com/onflow/cadence v1.9.6
 	github.com/onflow/crypto v0.25.3
 	github.com/onflow/flow/protobuf/go/flow v0.4.19
 	github.com/onflow/sdks v0.6.0-preview.1

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.12.0 h1:X7/UEPyCaaEQ1gCg11KDvfyEtEeQLhtRtxMHjAiH/Co=
 github.com/onflow/atree v0.12.0/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
-github.com/onflow/cadence v1.9.5 h1:m82RsERxvrknL69J9YxzOEKFhiHARBQkvNIFTUATGNk=
-github.com/onflow/cadence v1.9.5/go.mod h1:MlJsCwhCZwdnAUd24XHzcsizZfG7a2leab1PztabUsE=
+github.com/onflow/cadence v1.9.6 h1:Ya0y/Nzjyw9K3kvX+lGcYbng8ciorwYmECk1VaMLN8s=
+github.com/onflow/cadence v1.9.6/go.mod h1:MlJsCwhCZwdnAUd24XHzcsizZfG7a2leab1PztabUsE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.9.6](https://github.com/onflow/cadence/releases/tag/v1.9.6)

