### PR TITLE
Update to Cadence v1.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/kms v1.50.0
 	github.com/ethereum/go-ethereum v1.16.7
-	github.com/onflow/cadence v1.10.1
+	github.com/onflow/cadence v1.10.2
 	github.com/onflow/crypto v0.25.3
 	github.com/onflow/flow/protobuf/go/flow v0.4.19
 	github.com/onflow/sdks v0.6.0-preview.1
@@ -62,7 +62,7 @@ require (
 	github.com/logrusorgru/aurora/v4 v4.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/onflow/atree v0.15.0 // indirect
+	github.com/onflow/atree v0.16.0 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,10 +107,10 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/onflow/atree v0.15.0 h1:wIDhQBWlmTj4KD40lTdjIcog7UIUr5iHjIMjIOhuYGU=
-github.com/onflow/atree v0.15.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
-github.com/onflow/cadence v1.10.1 h1:wKr/JdBM7lHqVZgY3HA6KcjE1b7vES/1p902v4CT2ME=
-github.com/onflow/cadence v1.10.1/go.mod h1:WcBEohOspFyZ3unRlL/Zd5q0yZSCveWJq3me/FtoVRg=
+github.com/onflow/atree v0.16.0 h1:b+f/suzcnnr1Lx1KdJEjpn2CX+AKSAz1yIB30NQDutU=
+github.com/onflow/atree v0.16.0/go.mod h1:hiOT/vKK/Zyw34Ru9OFbfEemC5NnQ7SHFB43bN9/4qI=
+github.com/onflow/cadence v1.10.2 h1:wa0olSOUNgcxAxjJHbMU+zsvxzFXkm+FNANQTsfpdr8=
+github.com/onflow/cadence v1.10.2/go.mod h1:tyUNaYlAgeQVgfR2C38MI1dtFFjKay+yGGPMrCRc068=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.10.2](https://github.com/onflow/cadence/releases/tag/v1.10.2)

